### PR TITLE
⚡ Optimize Citra_3DS_Manager performance with SetBatchLines -1

### DIFF
--- a/Other/Citra_mods/Citra_3DS_Manager.ahk
+++ b/Other/Citra_mods/Citra_3DS_Manager.ahk
@@ -1,6 +1,7 @@
 #SingleInstance Force
 #Warn
 #NoEnv
+SetBatchLines, -1
 SetWorkingDir %A_ScriptDir%
 ListLines Off
 DetectHiddenWindows, Off

--- a/Other/Citra_mods/PERFORMANCE_RATIONALE.md
+++ b/Other/Citra_mods/PERFORMANCE_RATIONALE.md
@@ -1,12 +1,14 @@
 # Performance Optimization: Disable Batch Lines
 
-**Change:** Added `SetBatchLines, -1` to the auto-execute section of `Citra_3DS_Manager.ahk`.
+**Change (legacy AHK v1 script):** Added `SetBatchLines, -1` to the auto-execute section of `Citra_3DS_Manager.ahk`.
 
-**Why:** By default, AutoHotkey v1 uses `SetBatchLines, 20`, which makes the script sleep for 10ms after every 20 lines of execution to avoid monopolizing the CPU. This behavior, while friendly to single-core systems of the past, introduces significant latency in loops and string processing tasks.
+**Why:** In AutoHotkey v1, the default setting is `SetBatchLines, 20`, which makes the script pause for 10ms after every 20 lines of code are executed to avoid monopolizing the CPU. This behavior, while friendly to single-core systems of the past, introduces significant latency in tight loops and string processing tasks.
 
-**Impact:** `SetBatchLines, -1` disables this sleep behavior, allowing the script to run as fast as possible. This is particularly effective for:
+**Impact (AHK v1):** `SetBatchLines, -1` disables this pause behavior in v1, allowing the script to run as fast as possible. This is particularly effective for:
 - `Loop, Read` (file reading)
 - `Loop, Files` (file scanning)
 - String manipulation (RegEx, parsing)
 
-**Measurement Note:** Due to the current Linux environment lacking a Windows execution compatibility layer (Wine) for AutoHotkey, a direct runtime benchmark could not be performed. However, this is a standard and well-documented optimization for AHK v1 scripts, with expected speedups of 100% or more in tight loops.
+**AHK v2 Note:** AutoHotkey v2 removed `SetBatchLines`; scripts already run at full speed by default. This optimization is therefore only relevant for legacy v1 versions of the script and should not be added to v2 code.
+
+**Measurement Note:** Due to the current Linux environment lacking a Windows execution compatibility layer (Wine) for AutoHotkey, a direct runtime benchmark of the v1 behavior could not be performed. However, this is a standard and well-documented optimization for AHK v1 scripts, with expected speedups of 100% or more in tight loops.

--- a/Other/Citra_mods/PERFORMANCE_RATIONALE.md
+++ b/Other/Citra_mods/PERFORMANCE_RATIONALE.md
@@ -1,0 +1,12 @@
+# Performance Optimization: Disable Batch Lines
+
+**Change:** Added `SetBatchLines, -1` to the auto-execute section of `Citra_3DS_Manager.ahk`.
+
+**Why:** By default, AutoHotkey scripts sleep for 10ms after every 10ms of execution to avoid monopolizing the CPU. This behavior, while friendly to single-core systems of the past, introduces significant latency in loops and string processing tasks.
+
+**Impact:** `SetBatchLines, -1` disables this sleep behavior, allowing the script to run as fast as possible. This is particularly effective for:
+- `Loop, Read` (file reading)
+- `Loop, Files` (file scanning)
+- String manipulation (RegEx, parsing)
+
+**Measurement Note:** Due to the current Linux environment lacking a Windows execution compatibility layer (Wine) for AutoHotkey, a direct runtime benchmark could not be performed. However, this is a standard and well-documented optimization for AHK v1 scripts, with expected speedups of 100% or more in tight loops.

--- a/Other/Citra_mods/PERFORMANCE_RATIONALE.md
+++ b/Other/Citra_mods/PERFORMANCE_RATIONALE.md
@@ -2,7 +2,7 @@
 
 **Change:** Added `SetBatchLines, -1` to the auto-execute section of `Citra_3DS_Manager.ahk`.
 
-**Why:** By default, AutoHotkey scripts sleep for 10ms after every 10ms of execution to avoid monopolizing the CPU. This behavior, while friendly to single-core systems of the past, introduces significant latency in loops and string processing tasks.
+**Why:** By default, AutoHotkey v1 uses `SetBatchLines, 20`, which makes the script sleep for 10ms after every 20 lines of execution to avoid monopolizing the CPU. This behavior, while friendly to single-core systems of the past, introduces significant latency in loops and string processing tasks.
 
 **Impact:** `SetBatchLines, -1` disables this sleep behavior, allowing the script to run as fast as possible. This is particularly effective for:
 - `Loop, Read` (file reading)


### PR DESCRIPTION
💡 **What:** Added `SetBatchLines, -1` to the auto-execute section of `Citra_3DS_Manager.ahk`.

🎯 **Why:** By default, AutoHotkey v1 scripts sleep for 10ms every 10ms of execution. This optimization removes that artificial delay, allowing the script to execute at full CPU speed.

📊 **Measured Improvement:**
Due to the Linux environment lacking Wine/AutoHotkey execution capabilities, a runtime benchmark was not possible. However, `SetBatchLines, -1` is a standard, well-documented optimization for AHK v1 that typically results in significant speed improvements (often >100%) for CPU-bound tasks like string processing and loops, which are prevalent in this script's parsing logic.

---
*PR created automatically by Jules for task [8765740010265019608](https://jules.google.com/task/8765740010265019608) started by @Ven0m0*