### PR TITLE
Refactor MC_Bedrock to use dynamic path for SoundVolumeView

### DIFF
--- a/Lib/v2/AHK_Common.ahk
+++ b/Lib/v2/AHK_Common.ahk
@@ -36,3 +36,31 @@ InitScript(requireUIA := true, requireAdmin := false, optimize := true) {
     if optimize
         SetOptimalPerformance()
 }
+
+FindExe(name, fallbacks := []) {
+    if FileExist(name)
+        return name
+    Loop Parse, EnvGet("PATH"), ";"
+    {
+        p := Trim(A_LoopField)
+        if !p
+            continue
+        cand := p . "\" . name
+        if FileExist(cand)
+            return cand
+    }
+    for _, fb in fallbacks
+        if FileExist(fb)
+            return fb
+    return ""
+}
+
+MustGetExe(name, fallbacks := []) {
+    exe := FindExe(name, fallbacks)
+    if exe = ""
+    {
+        MsgBox("Required executable not found: " . name . "`nChecked PATH and fallbacks.")
+        ExitApp(1)
+    }
+    return exe
+}

--- a/Other/playnite-all.ahk
+++ b/Other/playnite-all.ahk
@@ -12,32 +12,6 @@
 InitScript(false, false, true)
 #SingleInstance Force
 
-FindExe(name, fallbacks := []) {
-    if FileExist(name)
-        return name
-    Loop Parse, EnvGet("PATH"), ";"
-    {
-        p := Trim(A_LoopField)
-        if !p
-            continue
-        cand := p . "\" . name
-        if FileExist(cand)
-            return cand
-    }
-    for _, fb in fallbacks
-        if FileExist(fb)
-            return fb
-    return ""
-}
-MustGetExe(name, fallbacks := []) {
-    exe := FindExe(name, fallbacks)
-    if exe = ""
-    {
-        MsgBox("Required executable not found: " . name . "`nChecked PATH and fallbacks.")
-        ExitApp(1)
-    }
-    return exe
-}
 ShowHelp() {
     MsgBox("Usage:`n  " . A_ScriptName . " <mode>`n`nModes:`n  fullscreen`n  tv`n  tv_firefox`n  tv_sound")
     ExitApp(1)

--- a/ahk/Minecraft/MC_Bedrock.ahk
+++ b/ahk/Minecraft/MC_Bedrock.ahk
@@ -2,11 +2,7 @@
 
 ; ============================================================================
 ; MC_Bedrock.ahk - Minecraft Bedrock Edition launcher with audio setup
-; Version: 2.0.0 (Migrated to AHK v2)
-;
-; WARNING: This script contains hardcoded paths that need customization:
-;   - ToolDir variable points to specific user directory
-;   - Adjust paths before use
+; Version: 2.1.0 (Migrated to AHK v2)
 ; ============================================================================
 
 #Include %A_ScriptDir%\..\..\Lib\v2\AHK_Common.ahk
@@ -15,19 +11,23 @@ InitScript(false, false, true)
 #SingleInstance Force
 Persistent
 
-; TODO: Update this path to match your system
-; Original: C:\Users\janni\OneDrive\Backup\Optimal\Scripts\Other\Playnite\Playnite Fullscreen
-ToolDir := A_ScriptDir . "\..\..\Other\Playnite_fullscreen"
+; Locate SoundVolumeView
+svv := FindExe("SoundVolumeView.exe", [
+    A_ScriptDir . "\..\..\Other\SoundVolumeView\SoundVolumeView.exe",
+    A_ScriptDir . "\..\..\Other\Playnite_fullscreen\SoundVolumeView\SoundVolumeView.exe"
+])
 
 ; Launch Minecraft Bedrock Edition
 Run("shell:AppsFolder\Microsoft.MinecraftUWP_8wekyb3d8bbwe!App")
 DllCall("kernel32.dll\Sleep", "UInt", 250)
 
 ; Set default audio devices (requires SoundVolumeView)
-try {
-    RunWait(ToolDir . "\SoundVolumeView\SoundVolumeView.exe /SetDefault `"THX Spatial - Synapse`"")
-    DllCall("kernel32.dll\Sleep", "UInt", 250)
-    RunWait(ToolDir . "\SoundVolumeView\SoundVolumeView.exe /SetDefault `"Razer Audio Controller - Game`"")
-} catch Error as err {
-    ; SoundVolumeView not found or error - continue anyway
+if (svv != "") {
+    try {
+        RunWait(svv . ' /SetDefault "THX Spatial - Synapse"')
+        DllCall("kernel32.dll\Sleep", "UInt", 250)
+        RunWait(svv . ' /SetDefault "Razer Audio Controller - Game"')
+    } catch Error as err {
+        ; Error executing SoundVolumeView - continue anyway
+    }
 }


### PR DESCRIPTION
- Moved `FindExe` and `MustGetExe` from `playnite-all.ahk` to `Lib/v2/AHK_Common.ahk` for reusability.
- Updated `MC_Bedrock.ahk` to use `FindExe` to locate `SoundVolumeView.exe` instead of a hardcoded user path.
- Cleaned up `playnite-all.ahk` to remove duplicate function definitions.
- Ensured graceful degradation if `SoundVolumeView` is not found.

---
*PR created automatically by Jules for task [10530591154500514658](https://jules.google.com/task/10530591154500514658) started by @Ven0m0*