### PR TITLE
Fix logic bug in _MakeMatchList handling of End parameter for columns

### DIFF
--- a/Other/Citra_per_game_config/tf.ahk
+++ b/Other/Citra_per_game_config/tf.ahk
@@ -1403,7 +1403,7 @@ Error 03: Invalid StartLine parameter (only one + allowed)`nFunction used: %Call
      If (Col = 1)
         {
          LongestLine:=TF_Stat(Text)
-         If (End > LongestLine) or (End = 1) ; FIXITHERE BUG
+         If (End > LongestLine) or (End = 0) or (End = "")
             End:=LongestLine
         }
 


### PR DESCRIPTION
The `_MakeMatchList` function had a logic bug where `End=1` was incorrectly treated as a request to process all columns (setting `End` to `LongestLine`). This prevented users from targeting just the first column.

This commit changes the condition to:
1. Respect `End=1` as targeting the first column.
2. Correctly default `End=0` or `End=""` to `LongestLine` (all columns).
3. Clamp `End` to `LongestLine` if it exceeds the column count.

---
*PR created automatically by Jules for task [454577034423850296](https://jules.google.com/task/454577034423850296) started by @Ven0m0*