### PR TITLE
⚡ Remove obsolete SetBatchLines to fix v2 script crash

### DIFF
--- a/ahk/Keys.ahk
+++ b/ahk/Keys.ahk
@@ -9,7 +9,6 @@ InitScript(true, false, false)  ; UIA required, no admin, manual tuning
 
 KeyHistory(0)
 ListLines False
-SetBatchLines(-1)
 SetKeyDelay(-1, -1)
 SetMouseDelay(-1)
 SetDefaultMouseSpeed(0)


### PR DESCRIPTION
💡 **What:** Removed the obsolete `SetBatchLines(-1)` function call from `ahk/Keys.ahk`.

🎯 **Why:** In AutoHotkey v2, the `SetBatchLines` function has been completely removed because all scripts now run at maximum execution speed by default (equivalent to `SetBatchLines -1` in v1, eliminating the 10ms delay between lines). Because `ahk/Keys.ahk` utilizes `#Requires AutoHotkey v2.0`, calling `SetBatchLines(-1)` causes an immediate "Call to nonexistent function" runtime error, crashing the script. Removing the nonexistent function resolves the startup crash while maintaining max performance as per AHK v2's default behavior.

📊 **Measured Improvement:** 
Due to the fact that the script crashes on launch, a runtime benchmark could not be collected (and dynamically benchmarking is also restricted in this Linux environment). The improvement is theoretical but absolute: transforming the script from a non-functional crashing state to executing at AutoHotkey v2's default maximum execution speed with zero inter-line delay.

---
*PR created automatically by Jules for task [903517936799392908](https://jules.google.com/task/903517936799392908) started by @Ven0m0*