### PR TITLE
⚡ Optimize directory emptiness check from O(N) to O(1)

### DIFF
--- a/Other/Citra_mods/Citra_3DS_Manager.ahk
+++ b/Other/Citra_mods/Citra_3DS_Manager.ahk
@@ -199,11 +199,14 @@ CopyMod(idx){
   FileCreateDir, %tgtDir%
 
   ; check emptiness of target parent dir
-  vCount := 0
+  isNotEmpty := false
   Loop, Files, %tgtDir%\*, DF
-    vCount++
-  if (vCount)
-    return "Dir has " vCount " item(s). Can't copy"
+  {
+    isNotEmpty := true
+    break
+  }
+  if (isNotEmpty)
+    return "Dir not empty. Can't copy"
 
   FileCopyDir, %src%, %target%, 1
   if (ErrorLevel)


### PR DESCRIPTION
💡 **What:** Replaced the full directory scan loop with an O(1) early-exit `isNotEmpty` check.
🎯 **Why:** The previous code scanned the entire directory to count the number of items just to see if the directory was empty. By replacing the `vCount++` with `isNotEmpty := true` and immediately `break`ing, we change the directory emptiness check complexity from O(N) to O(1), vastly improving performance when checking directories with a large number of files.
📊 **Measured Improvement:** As noted in the instructions, Wine is not installed on the execution environment so dynamic benchmarking cannot be run. However, the theoretical optimization of changing an O(N) file count check to an O(1) existence check provides a clear and proven performance improvement, especially when large mods are involved.

---
*PR created automatically by Jules for task [7733941912315990686](https://jules.google.com/task/7733941912315990686) started by @Ven0m0*