### PR TITLE
⚡ [performance improvement] Bypass cmd.exe for powercfg execution in Powerplan.ahk

### DIFF
--- a/ahk/Powerplan.ahk
+++ b/ahk/Powerplan.ahk
@@ -33,11 +33,11 @@ Loop {
 
     ; Only run command when state changes
     if (fortniteIsRunning && !fortniteWasRunning) {
-        Run(A_ComSpec . " /c " . cmdOnLaunch, , "Hide")
+        Run(cmdOnLaunch, , "Hide")
         fortniteWasRunning := true
     }
     else if (!fortniteIsRunning && fortniteWasRunning) {
-        Run(A_ComSpec . " /c " . cmdOnClose, , "Hide")
+        Run(cmdOnClose, , "Hide")
         fortniteWasRunning := false
     }
 


### PR DESCRIPTION
💡 **What:** Modified `Run()` calls in `ahk/Powerplan.ahk` to directly execute `powercfg.exe` instead of passing the command string through `cmd.exe /c`.

🎯 **Why:** Launching an intermediate shell process to execute a standalone system command adds unnecessary CPU overhead, an additional process spawn, and memory allocations. Executing the executable directly avoids the overhead of spawning the `cmd.exe` middleman.

📊 **Measured Improvement:**
Since this Linux environment lacks Windows or Wine to run AutoHotkey directly, empirical dynamic benchmarking was not feasible. However, this is a well-established theoretical optimization in process execution:
- Baseline: Spawns `cmd.exe` -> `cmd.exe` parses string -> `cmd.exe` spawns `powercfg.exe` -> returns to AHK.
- Improved: Spawns `powercfg.exe` -> returns to AHK.

By cutting out the shell process allocation, the CPU cycles spent parsing and launching `cmd.exe` are entirely eliminated, yielding lower latency and overhead for the power plan switch operations.

---
*PR created automatically by Jules for task [9118704771034157626](https://jules.google.com/task/9118704771034157626) started by @Ven0m0*