### PR TITLE
⚡ Optimize ControllerQuit by replacing polling loop with event-driven hotkeys

### DIFF
--- a/ahk/ControllerQuit.ahk
+++ b/ahk/ControllerQuit.ahk
@@ -12,7 +12,7 @@
 #SingleInstance Force
 
 ; Find first available joystick
-JoystickNumber := 0
+global JoystickNumber := 0
 Loop 16 {
     try {
         JoyName := GetKeyState(A_Index . "JoyName")
@@ -28,25 +28,24 @@ if (JoystickNumber == 0) {
     ExitApp()
 }
 
-; Get number of buttons
-joy_buttons := GetKeyState(JoystickNumber . "JoyButtons")
+; Register individual hotkeys for Joy9 & Joy10
+; This is event-driven and much more efficient than a continuous polling loop
+Hotkey(JoystickNumber . "Joy9", CheckButtons)
+Hotkey(JoystickNumber . "Joy10", CheckButtons)
 
-Loop {
-    ; Check all buttons
-    buttons_down := ""
-    Loop joy_buttons {
-        if (GetKeyState(JoystickNumber . "Joy" . A_Index)) {
-            buttons_down .= " " . A_Index
-        }
-    }
+; Keep script running since there is no longer a loop
+Persistent()
 
-    ; If Joy9 (Select) and Joy10 (Start) are pressed, close active window
-    if (InStr(buttons_down, " 9") && InStr(buttons_down, " 10")) {
+CheckButtons(HotkeyName) {
+    ; Extract the button number that was pressed (9 or 10)
+    pressed_btn := RegExReplace(HotkeyName, "^\d+Joy")
+    other_btn := (pressed_btn = "9") ? "10" : "9"
+
+    ; If the other button is also currently held down
+    if (GetKeyState(JoystickNumber . "Joy" . other_btn)) {
         ; Don't close desktop
         if (!WinActive("ahk_class WorkerW")) {
             WinClose("A")
         }
     }
-
-    Sleep(200)
 }


### PR DESCRIPTION
💡 **What:** Replaced the infinite `Loop` + `Sleep(200)` + `GetKeyState` polling mechanism in `ahk/ControllerQuit.ahk` with event-driven hotkeys (`Hotkey(..., CheckButtons)`).
🎯 **Why:** The continuous polling loop wasted CPU cycles unnecessarily checking the controller state every 200ms when idle. Event-driven hotkeys only wake up the CPU when the relevant buttons (`Joy9` and `Joy10`) are actually pressed.
📊 **Measured Improvement:** The complexity changes from O(N) over time (infinite continuous checks) to O(1) event-based execution. Because the environment (Linux) does not support running AutoHotkey via Wine natively, runtime benchmarking wasn't possible; however, avoiding constant CPU wakeups on idle is a universally accepted performance optimization.

Note: Added PR feedback fixes. JoyX & JoyY is an invalid custom hotkey syntax in AHK. We register individual hotkeys and evaluate the other button inside the callback.

---
*PR created automatically by Jules for task [6022072565037435365](https://jules.google.com/task/6022072565037435365) started by @Ven0m0*