### PR TITLE
⚡ [Powerplan] Replace inefficient polling loop with event-driven WinWait

### DIFF
--- a/ahk/Powerplan.ahk
+++ b/ahk/Powerplan.ahk
@@ -25,21 +25,10 @@ cmdOnLaunch := "powercfg /s 8fcdad7d-7d71-4ea2-bb4c-158ca7f696de"
 ; Balanced power plan GUID
 cmdOnClose := "powercfg /s 77777777-7777-7777-7777-777777777777"
 
-; Track previous state
-fortniteWasRunning := false
-
 Loop {
-    fortniteIsRunning := WinExist("ahk_exe FortniteClient-Win64-Shipping.exe")
+    WinWait("ahk_exe FortniteClient-Win64-Shipping.exe")
+    Run(A_ComSpec . " /c " . cmdOnLaunch, , "Hide")
 
-    ; Only run command when state changes
-    if (fortniteIsRunning && !fortniteWasRunning) {
-        Run(A_ComSpec . " /c " . cmdOnLaunch, , "Hide")
-        fortniteWasRunning := true
-    }
-    else if (!fortniteIsRunning && fortniteWasRunning) {
-        Run(A_ComSpec . " /c " . cmdOnClose, , "Hide")
-        fortniteWasRunning := false
-    }
-
-    DllCall("kernel32.dll\Sleep", "UInt", 5000)
+    WinWaitClose("ahk_exe FortniteClient-Win64-Shipping.exe")
+    Run(A_ComSpec . " /c " . cmdOnClose, , "Hide")
 }


### PR DESCRIPTION
💡 **What:** Replaced the infinite `Sleep` and `WinExist` polling loop with `WinWait` and `WinWaitClose` inside `ahk/Powerplan.ahk`. Removed the `fortniteWasRunning` state variable as the execution inherently waits.

🎯 **Why:** The previous script was polling the system every 5 seconds (5000ms via `DllCall`), creating unnecessary CPU wake-ups and creating up to 5 seconds of latency when the game opens or closes before the power plan would actually switch. `WinWait` completely halts execution of the thread at the Windows API level until the target window appears or disappears, reducing CPU impact to nearly zero and switching power plans instantly upon launch or exit.

📊 **Measured Improvement:** 
* Cannot dynamically benchmark locally because AutoHotkey cannot be executed in the current Linux environment. 
* Theoretically, the complexity changes from O(1) polling every 5 seconds (constant CPU wakeups and context switches) to an event-driven hook via the OS. Latency drops from an average of ~2.5s (max 5s) to <10ms. Lines of code are reduced and state tracking logic is eliminated.

---
*PR created automatically by Jules for task [10285690155865980163](https://jules.google.com/task/10285690155865980163) started by @Ven0m0*