### PR TITLE
⚡ Optimize Spider-Man start script by replacing fixed sleeps with WinWaitActive

### DIFF
--- a/Other/start_Spider-Man.ahk
+++ b/Other/start_Spider-Man.ahk
@@ -17,8 +17,7 @@ SetTitleMatchMode("Fast")
 
 ; Spider-Man requires Enter key to dismiss splash screen
 WinWait("ahk_exe Spider-Man.exe")
-Sleep(500)
+WinWaitActive("ahk_exe Spider-Man.exe")
 ControlSend("{Enter}", , "ahk_exe Spider-Man.exe")
-Sleep(3500)
 WinActivate("ahk_exe Spider-Man.exe")
 ExitApp()


### PR DESCRIPTION
💡 **What:** Replaced the hardcoded `Sleep(500)` and `Sleep(3500)` delays in `Other/start_Spider-Man.ahk` with a single, event-driven `WinWaitActive("ahk_exe Spider-Man.exe")` call.
🎯 **Why:** To make the splash screen dismissal faster and more reliable. A hardcoded sleep means the script must always wait 4000ms, regardless of how fast the window actually activates. Using `WinWaitActive` ensures the script proceeds immediately as soon as the target window is active, eliminating unnecessary blocking and reducing the startup time.
📊 **Measured Improvement:** As AHK v2 execution is unavailable in the current Linux environment, exact benchmarking cannot be run dynamically. However, theoretically, the execution replaces a fixed 4.0-second delay with an immediate event trigger, which can optimize the launch workflow by saving up to ~4 seconds depending on system load and game startup speed. This approach is standard practice in AutoHotkey window management.

---
*PR created automatically by Jules for task [924432669490100117](https://jules.google.com/task/924432669490100117) started by @Ven0m0*