### PR TITLE
⚡ perf: Add SetBatchLines -1 to Citra Mod Manager

### DIFF
--- a/Other/Citra_mods/Citra_Mod_Manager.ahk
+++ b/Other/Citra_mods/Citra_Mod_Manager.ahk
@@ -8,6 +8,7 @@ if (!InStr(A_AhkPath, "_UIA.exe")) {
 #SingleInstance Force
 #Warn ; Enable warnings to assist with detecting common errors.
 #NoEnv  ; Recommended for performance and compatibility with future AutoHotkey releases.
+SetBatchLines, -1
 SetWorkingDir % A_ScriptDir ; Ensures a consistent starting directory.
 Menu, Tray, Tip, Citra Mod Manager
 EnvGet OneDrive, ONEDRIVE


### PR DESCRIPTION
💡 **What:** Added `SetBatchLines, -1` to `Other/Citra_mods/Citra_Mod_Manager.ahk` right after `#NoEnv`.

🎯 **Why:** In legacy AutoHotkey v1 scripts, by default there is a 10ms sleep automatically inserted after every executing line. Adding `SetBatchLines, -1` disables this behavior entirely, allowing loops (like the file system and CSV parsing loops within the script) and general execution to run at maximum possible speed, which is a critical and standard optimization for AHK v1 code.

📊 **Measured Improvement:** No runtime benchmark could be performed because the current Linux environment lacks Wine and native Windows execution capabilities, making dynamic execution and performance measurement impossible. However, the theoretical improvement is undeniable and universally accepted: it removes a fixed 10ms-per-line sleep delay across all AutoHotkey execution loops within the script.

---
*PR created automatically by Jules for task [6770896811078666104](https://jules.google.com/task/6770896811078666104) started by @Ven0m0*