### PR TITLE
fix: add Ahk2Exe installer and correct action versions in workflows

### DIFF
--- a/.github/workflows/ahk-lint-format-compile.yml
+++ b/.github/workflows/ahk-lint-format-compile.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install AutoHotkey v1.1 (Portable)
         run: choco install autohotkey.portable --version=1.1.36.01 -y

--- a/.github/workflows/ahk-lint-format-compile.yml
+++ b/.github/workflows/ahk-lint-format-compile.yml
@@ -16,7 +16,7 @@ jobs:
   lint:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install AutoHotkey v1.1 (Portable)
         run: choco install autohotkey.portable --version=1.1.36.01 -y

--- a/.github/workflows/build-cached.yml
+++ b/.github/workflows/build-cached.yml
@@ -42,6 +42,14 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\Ahk2Exe.zip"
           New-Item -Type Directory -Force "C:\AutoHotkey-Portable\Compiler" | Out-Null
           Expand-Archive "$env:TEMP\Ahk2Exe.zip" -DestinationPath "C:\AutoHotkey-Portable\Compiler" -Force
+          $requiredFiles = @(
+            "C:\AutoHotkey-Portable\Compiler\Ahk2Exe.exe",
+            "C:\AutoHotkey-Portable\Compiler\AutoHotkeySC.bin"
+          )
+          $missingFiles = $requiredFiles | Where-Object { -not (Test-Path $_) }
+          if ($missingFiles) {
+            throw "Ahk2Exe extraction failed: expected compiler files were not found after expanding '$env:TEMP\Ahk2Exe.zip'. Missing: $($missingFiles -join ', '). Verify AHK2EXE_TAG '$env:AHK2EXE_TAG' and the Ahk2Exe.zip archive layout."
+          }
           Remove-Item "$env:TEMP\Ahk2Exe.zip"
 
       - name: Compile Scripts

--- a/.github/workflows/build-cached.yml
+++ b/.github/workflows/build-cached.yml
@@ -9,20 +9,21 @@ permissions:
   contents: write
 
 env:
-  AHK_VERSION: "2.0.19"
+  AHK_VERSION: "2.0.23"
+  AHK2EXE_TAG: "Ahk2Exe1.1.37.02a2"
 
 jobs:
   build-release:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
-      - name: Cache AutoHotkey
+      - name: Cache AutoHotkey and Ahk2Exe
         uses: actions/cache@v5
         id: cache-ahk
         with:
           path: C:\AutoHotkey-Portable
-          key: ahk-${{ env.AHK_VERSION }}
+          key: ahk-${{ env.AHK_VERSION }}-ahk2exe-${{ env.AHK2EXE_TAG }}
 
       - name: Install AutoHotkey
         if: steps.cache-ahk.outputs.cache-hit != 'true'
@@ -32,6 +33,16 @@ jobs:
           Expand-Archive ahk.zip -DestinationPath C:\AutoHotkey-Portable -Force
           Remove-Item ahk.zip
         shell: pwsh
+
+      - name: Install Ahk2Exe
+        if: steps.cache-ahk.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $url = "https://github.com/AutoHotkey/Ahk2Exe/releases/download/$env:AHK2EXE_TAG/Ahk2Exe.zip"
+          Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\Ahk2Exe.zip"
+          New-Item -Type Directory -Force "C:\AutoHotkey-Portable\Compiler" | Out-Null
+          Expand-Archive "$env:TEMP\Ahk2Exe.zip" -DestinationPath "C:\AutoHotkey-Portable\Compiler" -Force
+          Remove-Item "$env:TEMP\Ahk2Exe.zip"
 
       - name: Compile Scripts
         run: |
@@ -69,7 +80,7 @@ jobs:
         shell: pwsh
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*.exe
           fail_on_unmatched_files: true

--- a/.github/workflows/build-cached.yml
+++ b/.github/workflows/build-cached.yml
@@ -16,7 +16,7 @@ jobs:
   build-release:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Cache AutoHotkey and Ahk2Exe
         uses: actions/cache@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
   build-release:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install AutoHotkey
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,13 +9,14 @@ permissions:
   contents: write
 
 env:
-  AHK_VERSION: "2.0.19"
+  AHK_VERSION: "2.0.23"
+  AHK2EXE_TAG: "Ahk2Exe1.1.37.02a2"
 
 jobs:
   build-release:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install AutoHotkey
         shell: pwsh
@@ -24,6 +25,15 @@ jobs:
           Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\ahk.zip"
           Expand-Archive "$env:TEMP\ahk.zip" -DestinationPath C:\AutoHotkey-Portable -Force
           Remove-Item "$env:TEMP\ahk.zip"
+
+      - name: Install Ahk2Exe
+        shell: pwsh
+        run: |
+          $url = "https://github.com/AutoHotkey/Ahk2Exe/releases/download/$env:AHK2EXE_TAG/Ahk2Exe.zip"
+          Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\Ahk2Exe.zip"
+          New-Item -Type Directory -Force "C:\AutoHotkey-Portable\Compiler" | Out-Null
+          Expand-Archive "$env:TEMP\Ahk2Exe.zip" -DestinationPath "C:\AutoHotkey-Portable\Compiler" -Force
+          Remove-Item "$env:TEMP\Ahk2Exe.zip"
 
       - name: Compile Scripts
         run: |
@@ -61,7 +71,7 @@ jobs:
         shell: pwsh
 
       - name: Create Release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@v2
         with:
           files: release/*.exe
           fail_on_unmatched_files: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,9 +30,22 @@ jobs:
         shell: pwsh
         run: |
           $url = "https://github.com/AutoHotkey/Ahk2Exe/releases/download/$env:AHK2EXE_TAG/Ahk2Exe.zip"
+          $compilerDir = "C:\AutoHotkey-Portable\Compiler"
           Invoke-WebRequest -Uri $url -OutFile "$env:TEMP\Ahk2Exe.zip"
-          New-Item -Type Directory -Force "C:\AutoHotkey-Portable\Compiler" | Out-Null
-          Expand-Archive "$env:TEMP\Ahk2Exe.zip" -DestinationPath "C:\AutoHotkey-Portable\Compiler" -Force
+          New-Item -Type Directory -Force $compilerDir | Out-Null
+          Expand-Archive "$env:TEMP\Ahk2Exe.zip" -DestinationPath $compilerDir -Force
+
+          $requiredFiles = @(
+            "Ahk2Exe.exe"
+            "Unicode 32-bit.bin"
+            "Unicode 64-bit.bin"
+          )
+          $missingFiles = $requiredFiles | Where-Object {
+            -not (Test-Path (Join-Path $compilerDir $_))
+          }
+          if ($missingFiles) {
+            throw "Ahk2Exe extraction failed or archive layout changed. Missing expected files in '$compilerDir': $($missingFiles -join ', ')"
+          }
           Remove-Item "$env:TEMP\Ahk2Exe.zip"
 
       - name: Compile Scripts


### PR DESCRIPTION
## Summary

- **Add Ahk2Exe install step** to `build.yml` and `build-cached.yml` — the AHK v2 portable zip does not bundle the compiler, so it must be downloaded separately from [AutoHotkey/Ahk2Exe](https://github.com/AutoHotkey/Ahk2Exe/releases/tag/Ahk2Exe1.1.37.02a2) and extracted into `C:\AutoHotkey-Portable\Compiler\`
- **Fix `actions/checkout@v6`** → `@v4` in all three workflows (v6 does not exist)
- **Fix `softprops/action-gh-release@v3`** → `@v2` in both build workflows (v3 does not exist)
- **Update `AHK_VERSION`** from `2.0.19` → `2.0.23` (latest release)
- **Update cache key** in `build-cached.yml` to include the Ahk2Exe tag so cache invalidates when the compiler version changes

## Test plan

- [ ] Trigger `Build and Release` workflow via `workflow_dispatch` and verify the Ahk2Exe install step succeeds and scripts compile to `.exe`
- [ ] Trigger `Build and Release (Cached)` and confirm cache is populated on first run, then hit on subsequent runs
- [ ] Confirm `AHK Lint & Format` still passes on an `.ahk` file change

https://claude.ai/code/session_01MCZicEuheUfJmvEZ28nr2B

---
_Generated by [Claude Code](https://claude.ai/code/session_01MCZicEuheUfJmvEZ28nr2B)_