### PR TITLE
🧹 Centralize AHK v2 initialization and refactor Spider-Man launcher

### DIFF
--- a/Lib/v2/AHK_Common.ahk
+++ b/Lib/v2/AHK_Common.ahk
@@ -29,6 +29,12 @@ SetOptimalPerformance() {
 }
 
 InitScript(requireUIA := true, requireAdmin := false, optimize := true) {
+    SetWorkingDir(A_ScriptDir)
+    SetTitleMatchMode(2)
+    SetTitleMatchMode("Fast")
+    DetectHiddenText(false)
+    DetectHiddenWindows(false)
+
     if requireUIA
         InitUIA()
     if requireAdmin

--- a/Lib/v2/AutoStartHelper.ahk
+++ b/Lib/v2/AutoStartHelper.ahk
@@ -12,8 +12,10 @@ WaitWin(target, timeout := 0) {
 }
 
 MaybeActivateMaximize(target, maximize, activate) {
-    if activate
+    if activate {
         WinActivate(target)
+        WinWaitActive(target, , 5)
+    }
     if maximize
         WinMaximize(target)
 }
@@ -25,8 +27,11 @@ AutoStartFullscreen(exeName, fullscreenKey := "F11", maximize := true, delay := 
     if (delay > 0)
         Sleep(delay)
     MaybeActivateMaximize(target, maximize, activate)
-    if fullscreenKey != ""
+    if fullscreenKey != "" {
         ControlSend("{" . fullscreenKey . "}", , target)
+        if activate
+            WinActivate(target)
+    }
 }
 
 AutoStartFullscreenWithTitle(winTitle, fullscreenKey := "F11", maximize := true, delay := 0) {

--- a/Other/AutoStartConfig.ini
+++ b/Other/AutoStartConfig.ini
@@ -69,8 +69,8 @@ special=none
 
 [SpiderMan]
 exe=Spider-Man.exe
-key=F11
+key=Enter
 maximize=true
 delay=0
-activate=false
+activate=true
 special=none

--- a/Other/AutoStartManager.ahk
+++ b/Other/AutoStartManager.ahk
@@ -13,7 +13,6 @@
 
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
 #Include %A_ScriptDir%\..\Lib\v2\AutoStartHelper.ahk
-#SingleInstance Force
 
 ; Initialize script
 InitScript(true, false, true)

--- a/Other/Close_Window_v2.ahk
+++ b/Other/Close_Window_v2.ahk
@@ -12,11 +12,6 @@
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
 InitScript(false, false, true)
 
-#SingleInstance Force
-DetectHiddenText(false)
-DetectHiddenWindows(false)
-SetTitleMatchMode(2)
-
 ; Create group of safe windows that shouldn't be closed
 GroupAdd("Safe", "ahk_exe Explorer.EXE")
 GroupAdd("Safe", "ahk_class ExploreWClass")

--- a/Other/RemotePlay_Whatever.ahk
+++ b/Other/RemotePlay_Whatever.ahk
@@ -5,13 +5,7 @@
 ; ============================================================================
 
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
-#SingleInstance Force
-
 InitScript(false, false, true)
-
-SetWorkingDir(A_ScriptDir)
-SetTitleMatchMode(2)
-SetTitleMatchMode("Fast")
 
 ; Launch Steam (standard x86 installation path)
 steamPath := "C:\Program Files (x86)\Steam\steam.exe"

--- a/Other/playnite-all.ahk
+++ b/Other/playnite-all.ahk
@@ -10,7 +10,6 @@
 ; ============================================================================
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
 InitScript(false, false, true)
-#SingleInstance Force
 
 ShowHelp() {
     MsgBox("Usage:`n  " . A_ScriptName . " <mode>`n`nModes:`n  fullscreen`n  tv`n  tv_firefox`n  tv_sound")

--- a/Other/start_Spider-Man.ahk
+++ b/Other/start_Spider-Man.ahk
@@ -5,19 +5,8 @@
 ; ============================================================================
 
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
-#SingleInstance Force
-
 InitScript(false, false, true)
 
-SetWorkingDir(A_ScriptDir)
-DetectHiddenText(false)
-DetectHiddenWindows(false)
-SetTitleMatchMode(2)
-SetTitleMatchMode("Fast")
-
-; Spider-Man requires Enter key to dismiss splash screen
-WinWait("ahk_exe Spider-Man.exe")
-WinWaitActive("ahk_exe Spider-Man.exe")
-ControlSend("{Enter}", , "ahk_exe Spider-Man.exe")
-WinActivate("ahk_exe Spider-Man.exe")
+; Run unified AutoStartManager for SpiderMan
+Run('"' . A_AhkPath . '" "' . A_ScriptDir . '\AutoStartManager.ahk" SpiderMan')
 ExitApp()

--- a/ahk/Fullscreen.ahk
+++ b/ahk/Fullscreen.ahk
@@ -20,7 +20,6 @@
 #Include %A_ScriptDir%\..\Lib\v2\WindowManager.ahk
 
 InitScript(true, true, true)  ; UIA + Admin + Performance optimizations
-#SingleInstance Force
 Persistent
 
 ; ============================================================================

--- a/ahk/GUI/GUI_Shared.ahk
+++ b/ahk/GUI/GUI_Shared.ahk
@@ -10,7 +10,6 @@
 #Include %A_ScriptDir%\..\..\Lib\v2\AHK_Common.ahk
 InitScript(true, true, true)  ; UIA + Admin + Performance
 
-#SingleInstance Force
 Persistent
 
 global gButtonActions := Map()

--- a/ahk/Minecraft/MC_Bedrock.ahk
+++ b/ahk/Minecraft/MC_Bedrock.ahk
@@ -8,7 +8,6 @@
 #Include %A_ScriptDir%\..\..\Lib\v2\AHK_Common.ahk
 InitScript(false, false, true)
 
-#SingleInstance Force
 Persistent
 
 ; Locate SoundVolumeView

--- a/ahk/Powerplan.ahk
+++ b/ahk/Powerplan.ahk
@@ -16,7 +16,6 @@
 #Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
 InitScript(false, false, true)
 
-#SingleInstance Force
 Persistent
 
 ; High Performance power plan GUID


### PR DESCRIPTION
This PR addresses duplication in the AutoHotkey v2 initialization scripts. It centralizes common environment setup within the `InitScript` function in `Lib/v2/AHK_Common.ahk` and refactors the `start_Spider-Man.ahk` script to use the project's unified `AutoStartManager.ahk` framework. Additionally, it cleans up redundant boilerplate across multiple scripts to improve maintainability and readability.

Key changes:
- **Centralized Initialization:** `InitScript` now handles `SetWorkingDir`, `SetTitleMatchMode`, `DetectHiddenText`, and `DetectHiddenWindows`.
- **Data-Driven Launcher:** `start_Spider-Man.ahk` logic moved to `AutoStartConfig.ini`, enabling use of the shared manager.
- **Improved Reliability:** `AutoStartHelper.ahk` updated with `WinWaitActive` for more robust window activation.
- **Cleanup:** Removed duplicate settings and `#SingleInstance Force` from 9 scripts that already include the common library.

---
*PR created automatically by Jules for task [9939423355980500465](https://jules.google.com/task/9939423355980500465) started by @Ven0m0*