### PR TITLE
🔒 Fix Command Injection in YT_Spotify_Downloader.ahk

### DIFF
--- a/Other/Downloader/YT_Spotify_Downloader.ahk
+++ b/Other/Downloader/YT_Spotify_Downloader.ahk
@@ -25,7 +25,7 @@ Return
 YTDLP:
   GuiControlGet, Youtube
   ; Add "yt-dlp.exe" in front of the input text
-  Cmd := "yt-dlp.exe --paths %userprofile%\Music -f ""bv*[height=1080]+ba/b"" --merge-output-format mp4 " . Youtube
+  Cmd := "yt-dlp.exe --paths %userprofile%\Music -f ""bv*[height=1080]+ba/b"" --merge-output-format mp4 -- """ . Youtube . """"
   ; Update the GroupBox with the combined text
   GuiControl,, Output, % Cmd
 return
@@ -33,7 +33,7 @@ return
 SpotYoutube:
   GuiControlGet, Spotify
   ; Add "spotdl" in front of the input text
-  Cmd := "spotdl download " Spotify " --output %userprofile%\Music --preload --sponsor-block --threads 16 "
+  Cmd := "spotdl download --output %userprofile%\Music --preload --sponsor-block --threads 16 -- """ . Spotify . """"
   ; Update the GroupBox with the combined text
   GuiControl,, Output, % Cmd
 return
@@ -41,8 +41,8 @@ return
 ; Function to validate input for command injection
 ValidateInput(input) {
     ; Check for dangerous characters that could enable command injection
-    ; Dangerous: & | ; < > ( ) $ ` ^ "
-    if RegExMatch(input, "[&|;<>()`$^""]") {
+    ; Dangerous: & | ; < > ( ) $ ` ^ " % !
+    if RegExMatch(input, "[&|;<>()``$^""%!]") {
         return false
     }
     return true
@@ -58,7 +58,7 @@ RunCmd:
 
   ; Validate input before executing
   if (!ValidateInput(inputToValidate)) {
-      MsgBox, 16, Security Error, Invalid characters detected in URL!`n`nThe following characters are not allowed:`n& | ; < > ( ) $ `` ^ "
+      MsgBox, 16, Security Error, Invalid characters detected in URL!`n`nThe following characters are not allowed:`n& | ; < > ( ) $ `` ^ " % !
       return
   }
 


### PR DESCRIPTION
🎯 **What:** This PR fixes a command injection vulnerability in the `YT_Spotify_Downloader.ahk` script.

⚠️ **Risk:** Previously, a malicious user could provide crafted input (e.g., URLs containing shell operators or command-line flags like `--exec`) to execute arbitrary local commands via `yt-dlp`, `spotdl`, or the Windows command processor (`cmd.exe`).

🛡️ **Solution:** The fix implements a multi-layered "Defense in Depth" approach:
1. **Argument Termination:** Uses the `--` separator to ensure that all user-provided input is treated strictly as a positional argument (the URL or search query) and not as a command-line flag.
2. **Quoting:** Correctly wraps user input in double quotes using AutoHotkey's escaping syntax (`""" . Var . """"`), preventing the shell from splitting the input into multiple arguments.
3. **Hardened Validation:** Updates the `ValidateInput` function's regex to block additional dangerous characters, specifically `%` and `!` to prevent environment variable expansion and delayed expansion attacks in Windows CMD.
4. **Correct Escaping:** Fixes the escaping of the backtick character (`` `` ``) in the AutoHotkey regex string to ensure it is correctly matched and blocked.
5. **User Feedback:** Updates the security `MsgBox` to inform users of the newly forbidden characters.

These changes ensure that the downloader script can safely handle various inputs while remaining functional for legitimate YouTube and Spotify URLs.

---
*PR created automatically by Jules for task [8960514269487906531](https://jules.google.com/task/8960514269487906531) started by @Ven0m0*