### PR TITLE
🧪 Test improvements for SetKey in CitraConfigHelpers

### DIFF
--- a/Other/Citra_per_game_config/v2/tests/TestSetKey.ahk
+++ b/Other/Citra_per_game_config/v2/tests/TestSetKey.ahk
@@ -1,0 +1,74 @@
+#Requires AutoHotkey v2.0
+#Include ../CitraConfigHelpers.ahk
+
+; Simple test framework
+global testsPassed := 0
+global testsFailed := 0
+
+AssertEqual(expected, actual, testName) {
+    global testsPassed, testsFailed
+    if (expected == actual) {
+        testsPassed++
+        FileAppend("PASS: " . testName . "`n", "*")
+    } else {
+        testsFailed++
+        FileAppend("FAIL: " . testName . "`n", "*")
+        FileAppend("  Expected: " . expected . "`n", "*")
+        FileAppend("  Actual:   " . actual . "`n", "*")
+    }
+}
+
+; Test Setup
+RunTests() {
+    global testsPassed, testsFailed
+
+    ; 1. Happy path: Key exists and is replaced
+    content1 := "key1=value1`nkey2=value2"
+    expected1 := "key1=new_value`nkey2=value2"
+    AssertEqual(expected1, SetKey(content1, "key1", "new_value"), "Key exists")
+
+    ; 2. Happy path: Key does not exist and is appended
+    content2 := "key1=value1"
+    expected2 := "key1=value1`nkey2=value2"
+    AssertEqual(expected2, SetKey(content2, "key2", "value2"), "Key does not exist")
+
+    ; 3. Edge case: Empty content
+    content3 := ""
+    expected3 := "`nkey1=value1"
+    AssertEqual(expected3, SetKey(content3, "key1", "value1"), "Empty content")
+
+    ; 4. Edge case: Key with surrounding spaces
+    ; INI keys can have spaces before =. SetKey regex uses \s*=.*
+    content4 := "key1 = value1"
+    expected4 := "key1=new_value"
+    AssertEqual(expected4, SetKey(content4, "key1", "new_value"), "Key with spaces before equals")
+
+    ; 5. Edge case: Key containing regex special characters
+    content5 := "key[1].test=value1"
+    expected5 := "key[1].test=new_value"
+    AssertEqual(expected5, SetKey(content5, "key[1].test", "new_value"), "Key with regex characters")
+
+    ; 6. Edge case: Multiple identical keys (should only replace the first one)
+    content6 := "key1=value1`nkey1=value2"
+    expected6 := "key1=new_value`nkey1=value2"
+    AssertEqual(expected6, SetKey(content6, "key1", "new_value"), "Duplicate keys")
+
+    ; 7. Edge case: Key value is empty
+    content7 := "key1="
+    expected7 := "key1=new_value"
+    AssertEqual(expected7, SetKey(content7, "key1", "new_value"), "Empty key value")
+
+    ; 8. Edge case: Newline at end of string
+    content8 := "key1=value1`n"
+    expected8 := "key1=new_value`n"
+    AssertEqual(expected8, SetKey(content8, "key1", "new_value"), "Trailing newline")
+
+    ; Print Summary
+    FileAppend("`nTest Summary: " . testsPassed . " passed, " . testsFailed . " failed.`n", "*")
+
+    if (testsFailed > 0) {
+        ExitApp(1)
+    }
+}
+
+RunTests()


### PR DESCRIPTION
🎯 **What:** The testing gap in `SetKey` from `CitraConfigHelpers.ahk` where string replacements using regular expressions were missing edge case tests.
  
📊 **Coverage:** The new test script (`TestSetKey.ahk`) introduces a lightweight, zero-dependency testing framework. It covers the following scenarios:
  - Happy path: Replacing an existing key.
  - Happy path: Appending a key that does not exist.
  - Edge case: Empty input string.
  - Edge case: Keys containing spaces before `=`.
  - Edge case: Keys containing regex special characters.
  - Edge case: Multiple identical keys (ensuring only the first match is modified).
  - Edge case: An empty key value.
  - Edge case: Strings with trailing newlines.

✨ **Result:** Test coverage for `SetKey` is improved by thoroughly validating string manipulation behavior, providing a safety net for future refactoring.

---
*PR created automatically by Jules for task [13693500837710155245](https://jules.google.com/task/13693500837710155245) started by @Ven0m0*