### PR TITLE
🧪 Add tests for 7zEmuPrepper Validate-Path

### DIFF
--- a/Other/7zEmuPrepper/7zEmuPrepper.Tests.ps1
+++ b/Other/7zEmuPrepper/7zEmuPrepper.Tests.ps1
@@ -1,0 +1,25 @@
+$ErrorActionPreference = 'Stop'
+. $PSScriptRoot\7zEmuPrepper.ps1
+
+Describe "7zEmuPrepper" {
+    Context "Validate-Path" {
+        It "Passes when -File path exists" {
+            New-Item -ItemType File -Path "TestDrive:\mockfile.txt" | Out-Null
+            { Validate-Path -path "TestDrive:\mockfile.txt" -File -name "TestFile" } | Should -Not -Throw
+        }
+        It "Throws when -File path does not exist" {
+            { Validate-Path -path "TestDrive:\missingfile.txt" -File -name "TestFile" } | Should -Throw "TestFile not found: TestDrive:\missingfile.txt"
+        }
+        It "Passes when -Dir path exists" {
+            New-Item -ItemType Directory -Path "TestDrive:\mockdir" | Out-Null
+            { Validate-Path -path "TestDrive:\mockdir" -Dir -name "TestDir" } | Should -Not -Throw
+        }
+        It "Throws when -Dir path does not exist" {
+            { Validate-Path -path "TestDrive:\missingdir" -Dir -name "TestDir" } | Should -Throw "TestDir not found: TestDrive:\missingdir"
+        }
+        It "Throws when -File expects leaf but gets container" {
+            New-Item -ItemType Directory -Path "TestDrive:\mockdir_as_file" | Out-Null
+            { Validate-Path -path "TestDrive:\mockdir_as_file" -File -name "TestFile" } | Should -Throw "TestFile not found: TestDrive:\mockdir_as_file"
+        }
+    }
+}

--- a/Other/7zEmuPrepper/7zEmuPrepper.ps1
+++ b/Other/7zEmuPrepper/7zEmuPrepper.ps1
@@ -18,7 +18,7 @@ param(
 $ErrorActionPreference = "Stop"
 
 function Write-Info { param($msg) Write-Host $msg }
-function Fail { param($msg) Write-Error $msg; exit 1 }
+function Fail { param($msg) throw $msg }
 
 function Validate-Path {
     param($path, [switch]$File, [switch]$Dir, [string]$name)
@@ -70,6 +70,7 @@ function Launch-Emulator {
     Start-Process -FilePath $emu -ArgumentList $fullArgs -Wait
 }
 
+if ($MyInvocation.InvocationName -ne '.') {
 # --- Validation ---
 Validate-Path -File $SevenZipPath -name "7-Zip"
 Validate-Path -File $EmulatorPath -name "Emulator"
@@ -110,4 +111,5 @@ try {
     Write-Info "Process complete."
 } finally {
     Pop-Location
+}
 }


### PR DESCRIPTION
🎯 **What:** The `Validate-Path` function in `7zEmuPrepper.ps1` lacked any test coverage and failed the code requirements for testability.
📊 **Coverage:** A new Pester test suite (`7zEmuPrepper.Tests.ps1`) was added. The tests mock environments using Pester's `TestDrive:` and validate parameters like `-File` and `-Dir`. They verify appropriate error throwing behaviors on invalid paths and successful returns on valid paths. Additionally, the main script was made testable by using a `throw` instead of an `exit` in the `Fail` function and appending an `if ($MyInvocation.InvocationName -ne '.')` guard block to prevent execution side-effects during dot-sourcing.
✨ **Result:** Test coverage for `Validate-Path` has been fully implemented, eliminating previous untestable conditions and improving the script's robustness overall.

---
*PR created automatically by Jules for task [13304894998334983949](https://jules.google.com/task/13304894998334983949) started by @Ven0m0*