### PR TITLE
🧪 Test: Fix WaitWin logic and add timeout test coverage

### DIFF
--- a/Lib/v2/AutoStartHelper.ahk
+++ b/Lib/v2/AutoStartHelper.ahk
@@ -3,12 +3,7 @@
 ; AutoStartHelper – wait, maximize, fullscreen helpers
 
 WaitWin(target, timeout := 0) {
-    try {
-        WinWait(target, , timeout)
-        return true
-    } catch TimeoutError {
-        return false
-    }
+    return WinWait(target, , timeout) != 0
 }
 
 MaybeActivateMaximize(target, maximize, activate) {

--- a/Lib/v2/Tests/AutoStartHelper_Test.ahk
+++ b/Lib/v2/Tests/AutoStartHelper_Test.ahk
@@ -1,0 +1,11 @@
+#Requires AutoHotkey v2.0
+#Include %A_ScriptDir%\..\AutoStartHelper.ahk
+
+Test_WaitWin_Timeout() {
+    result := WaitWin("NonExistentWindowTitle_1234567890", 0.1)
+    if (result != 0) {
+        throw Error("Test failed: WaitWin should return false (0) for a nonexistent window, got " . result)
+    }
+}
+
+Test_WaitWin_Timeout()


### PR DESCRIPTION
🎯 **What:** Added missing test coverage for `WaitWin` and fixed an underlying logical bug where it falsely relied on `TimeoutError` (AHK v2 `WinWait` returns 0 on timeout instead of throwing).

📊 **Coverage:** A new unit test script `AutoStartHelper_Test.ahk` now strictly checks timeout behavior when passed a nonexistent window title.

✨ **Result:** Corrected `WaitWin` return parsing to reliably detect timeouts, significantly improving AutoStart flow stability.

---
*PR created automatically by Jules for task [14157764359196530487](https://jules.google.com/task/14157764359196530487) started by @Ven0m0*