### PR TITLE
🧪 Add test for PerformAction run exception

### DIFF
--- a/ahk/GUI/PerformAction_Test.ahk
+++ b/ahk/GUI/PerformAction_Test.ahk
@@ -1,0 +1,34 @@
+#Requires AutoHotkey v2.0
+#Include GUI_Shared.ahk
+
+global testPassed := false
+global targetMsgBoxTitle := "Run Error"
+
+; Set a timer to close the error message box
+SetTimer(CloseErrorMsgBox, 50)
+
+; Create action with invalid run path
+badAction := Map("run", "Z:\NonExistentDrive\ThisExecutableDoesNotExist12345.exe")
+
+; Perform action - this should trigger the run exception and show a MsgBox
+PerformAction(badAction)
+
+; Cleanup timer
+SetTimer(CloseErrorMsgBox, 0)
+
+; Check result
+if (testPassed) {
+    FileAppend("PASS: PerformAction correctly handled invalid run exception.`n", "*")
+    ExitApp(0)
+} else {
+    FileAppend("FAIL: PerformAction did not handle invalid run exception as expected (MsgBox not shown/closed).`n", "*")
+    ExitApp(1)
+}
+
+CloseErrorMsgBox() {
+    global testPassed, targetMsgBoxTitle
+    if WinExist(targetMsgBoxTitle) {
+        WinClose(targetMsgBoxTitle)
+        testPassed := true
+    }
+}


### PR DESCRIPTION
🎯 **What:** Added test coverage for `PerformAction` to handle an invalid `Run` executable path. Because a `MsgBox` blocks test execution in AutoHotkey v2, the test uses an asynchronous `SetTimer` to close the message box, allowing the test to assert correctly.
📊 **Coverage:** Added test for `GUI_Shared.ahk`'s `PerformAction` function specifically testing `action.run` fail conditions.
✨ **Result:** Increases error-path test coverage for GUI logic, ensuring run errors don't cause the launcher script to crash silently.

---
*PR created automatically by Jules for task [1165046783553322229](https://jules.google.com/task/1165046783553322229) started by @Ven0m0*