### PR TITLE
🧪 Add testing for AHK_Common FindExe function

### DIFF
--- a/tests/FindExe_Test.ahk
+++ b/tests/FindExe_Test.ahk
@@ -1,0 +1,77 @@
+#Requires AutoHotkey v2.0
+#SingleInstance Force
+
+#Include %A_ScriptDir%\..\Lib\v2\AHK_Common.ahk
+
+InitScript(false, false, false) ; disable UIA, Admin, and optimization for the test
+
+; Setup testing output
+stdout := FileOpen("*", "w `n")
+testsPassed := 0
+testsFailed := 0
+
+AssertEqual(expected, actual, context) {
+    global testsPassed, testsFailed, stdout
+    if (expected == actual) {
+        testsPassed++
+        stdout.WriteLine("PASS: " . context)
+    } else {
+        testsFailed++
+        stdout.WriteLine("FAIL: " . context . " - Expected '" . expected . "', but got '" . actual . "'")
+    }
+}
+
+; Setup Mock Environment
+originalPath := EnvGet("PATH")
+testBaseDir := A_Temp . "\FindExe_Tests_" . A_TickCount
+
+DirCreate(testBaseDir)
+DirCreate(testBaseDir . "\PathDir1")
+DirCreate(testBaseDir . "\PathDir2")
+DirCreate(testBaseDir . "\FallbackDir")
+
+; Create dummy files
+FileAppend("", testBaseDir . "\PathDir2\tool.exe")
+FileAppend("", testBaseDir . "\FallbackDir\fbtool.exe")
+FileAppend("", testBaseDir . "\direct.exe")
+
+mockPath := testBaseDir . "\PathDir1;" . testBaseDir . "\PathDir2"
+EnvSet("PATH", mockPath)
+
+try {
+    stdout.WriteLine("Starting tests...")
+
+    ; Test 1: Direct file path
+    directPath := testBaseDir . "\direct.exe"
+    AssertEqual(directPath, FindExe(directPath), "Should return the exact path if it exists")
+
+    ; Test 2: Found in PATH
+    AssertEqual(testBaseDir . "\PathDir2\tool.exe", FindExe("tool.exe"), "Should resolve tool.exe from PATH")
+
+    ; Test 3: Not in PATH, found in fallback
+    fallbacks := [testBaseDir . "\FallbackDir\fbtool.exe"]
+    AssertEqual(testBaseDir . "\FallbackDir\fbtool.exe", FindExe("fbtool.exe", fallbacks), "Should resolve fbtool.exe from fallbacks")
+
+    ; Test 4: File not found anywhere
+    AssertEqual("", FindExe("nonexistent.exe", [testBaseDir . "\FallbackDir\missing.exe"]), "Should return empty string if not found anywhere")
+
+    ; Test 5: Empty PATH entries (should skip gracefully)
+    EnvSet("PATH", ";;" . mockPath . ";;")
+    AssertEqual(testBaseDir . "\PathDir2\tool.exe", FindExe("tool.exe"), "Should handle empty entries in PATH")
+
+    ; Final Results
+    stdout.WriteLine("---")
+    stdout.WriteLine("Tests Passed: " . testsPassed)
+    stdout.WriteLine("Tests Failed: " . testsFailed)
+
+} finally {
+    ; Teardown
+    EnvSet("PATH", originalPath)
+    DirDelete(testBaseDir, true)
+}
+
+if (testsFailed > 0) {
+    ExitApp(1)
+}
+
+ExitApp(0)


### PR DESCRIPTION
🎯 **What:** The `FindExe` function in `Lib/v2/AHK_Common.ahk` was previously untested, requiring manual verification of environment variable manipulation and path resolution logic.
📊 **Coverage:** A new standalone test script (`tests/FindExe_Test.ahk`) was created that covers:
  - Exact file path matches
  - Resolution of executables across simulated `PATH` directories
  - Graceful handling of empty or malformed `PATH` entries
  - Resolution via provided fallback paths
  - Correct failure behavior when a file cannot be found
✨ **Result:** Test coverage for `AHK_Common.ahk` has been significantly improved. The logic is now verified using an automated headless AutoHotkey v2 test utilizing custom assertions and standard output logging, ensuring no regressions when modifying core path resolution logic.

---
*PR created automatically by Jules for task [10146106065823549422](https://jules.google.com/task/10146106065823549422) started by @Ven0m0*