### PR TITLE
🧪 Add error handling test for SaveConfig

### DIFF
--- a/Other/Citra_per_game_config/v2/tests/CitraConfigHelpers.Tests.ahk
+++ b/Other/Citra_per_game_config/v2/tests/CitraConfigHelpers.Tests.ahk
@@ -1,0 +1,41 @@
+#Requires AutoHotkey v2.0
+#Include ../CitraConfigHelpers.ahk
+
+CloseMsgBox() {
+    if WinExist("Config Save Error") {
+        WinClose("Config Save Error")
+    }
+}
+
+TestSaveConfigError() {
+    stdout := FileOpen("*", "w `n")
+    stdout.Write("Running TestSaveConfigError...`n")
+
+    ; Create a directory to use as the "file" path to trigger a FileAppend error
+    testDirPath := A_ScriptDir . "\test_locked_file"
+    if !DirExist(testDirPath)
+        DirCreate(testDirPath)
+
+    ; Start a timer to dismiss the MsgBox that SaveConfig will show on failure
+    SetTimer(CloseMsgBox, 50)
+
+    ; Attempt to save to a directory, which will fail
+    result := SaveConfig("test configuration content", testDirPath)
+
+    ; Stop the timer
+    SetTimer(CloseMsgBox, 0)
+
+    ; Clean up
+    if DirExist(testDirPath)
+        DirRemove(testDirPath)
+
+    if (result == false) {
+        stdout.Write("PASS: SaveConfig correctly returned false on error.`n")
+    } else {
+        stdout.Write("FAIL: SaveConfig returned true despite an error condition.`n")
+        ExitApp(1)
+    }
+}
+
+TestSaveConfigError()
+ExitApp(0)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: Missing error test in SaveConfig in CitraConfigHelpers.ahk. The code attempts a `FileAppend` and catches exceptions, returning false. We needed a test for this error path.
📊 **Coverage:** Tests the failure scenario where `SaveConfig` fails to write configuration content. The exception is triggered reliably by attempting to overwrite a directory instead of an actual file. It also uses `SetTimer` to programmatically dismiss the AHK `MsgBox` that is spawned on error so tests don't hang in CI.
✨ **Result:** The codebase now contains automated test coverage for the `SaveConfig` error path.

---
*PR created automatically by Jules for task [16374003917407829245](https://jules.google.com/task/16374003917407829245) started by @Ven0m0*