### PR TITLE
🧪 Add error path testing for RequireAdmin

### DIFF
--- a/Lib/v2/AHK_Common.ahk
+++ b/Lib/v2/AHK_Common.ahk
@@ -7,11 +7,15 @@ InitUIA() {
     ; UIA is built-in in v2 (no-op, kept for compatibility)
 }
 
-RequireAdmin() {
-    if A_IsAdmin
+RequireAdmin(mockIsAdmin := "", mockRun := "") {
+    isAdmin := mockIsAdmin !== "" ? mockIsAdmin : A_IsAdmin
+    if isAdmin
         return
     try {
-        Run('*RunAs "' . A_ScriptFullPath . '"')
+        if mockRun !== ""
+            mockRun('*RunAs "' . A_ScriptFullPath . '"')
+        else
+            Run('*RunAs "' . A_ScriptFullPath . '"')
         ExitApp()
     } catch Error as err {
         MsgBox("Failed to elevate: " . err.Message)

--- a/Lib/v2/test_RequireAdmin.ahk
+++ b/Lib/v2/test_RequireAdmin.ahk
@@ -1,0 +1,31 @@
+#Requires AutoHotkey v2.0
+#Include AHK_Common.ahk
+
+MockRun(target) {
+    throw Error("Simulated elevation failure")
+}
+
+CloseMsgBox() {
+    if WinExist("ahk_class #32770") {
+        text := WinGetText("ahk_class #32770")
+        if InStr(text, "Failed to elevate: Simulated elevation failure") {
+            WinClose()
+            out := FileOpen("*", "w `n")
+            out.Write("Test Passed: Caught simulated elevation failure.`n")
+            out.Close()
+            ExitApp(0)
+        }
+    }
+}
+
+; Set up a timer to catch and close the MsgBox asynchronously
+SetTimer(CloseMsgBox, 50)
+
+; Trigger the error path
+RequireAdmin(false, MockRun)
+
+; Fallback failure if the async process fails or the error is never triggered
+out := FileOpen("*", "w `n")
+out.Write("Test Failed: Error MsgBox not encountered or test timed out.`n")
+out.Close()
+ExitApp(1)


### PR DESCRIPTION
🎯 **What:** Mocking capability and test file added for RequireAdmin error path
📊 **Coverage:** Elevated execution failure scenario resulting in an error MsgBox
✨ **Result:** Prevents regressions in the critical administrative permission handling

---
*PR created automatically by Jules for task [7659242922980956894](https://jules.google.com/task/7659242922980956894) started by @Ven0m0*