### PR TITLE
🧪 Add testing and dependency injection for WindowManager ToggleFakeFullscreen

### DIFF
--- a/Lib/v2/WindowManager.ahk
+++ b/Lib/v2/WindowManager.ahk
@@ -5,15 +5,18 @@
 static STYLE_DECORATIONS := 0xEC0000      ; title/menu/frame/sysmodal combined
 static STYLE_UNDECORATED := -0xEC0000
 
-ToggleFakeFullscreen(winTitle := "A") {
-    current := WinGetStyle(winTitle)
+ToggleFakeFullscreen(winTitle := "A", api := "") {
+    if !api
+        api := SystemWindowAPI()
+
+    current := api.WinGetStyle(winTitle)
     hasTitle := current & 0xC00000
     if hasTitle {
-        WinSetStyle(STYLE_UNDECORATED, winTitle)
-        WinMove(0, 0, A_ScreenWidth, A_ScreenHeight, winTitle)
+        api.WinSetStyle(STYLE_UNDECORATED, winTitle)
+        api.WinMove(0, 0, api.GetScreenWidth(), api.GetScreenHeight(), winTitle)
     } else {
-        WinSetStyle(STYLE_DECORATIONS, winTitle)
-        WinRestore(winTitle)
+        api.WinSetStyle(STYLE_DECORATIONS, winTitle)
+        api.WinRestore(winTitle)
     }
 }
 
@@ -84,4 +87,13 @@ ToggleFakeFullscreenMultiMonitor(winTitle := "A") {
 
 RestoreWindowBorders(winTitle) {
     WinSetStyle(STYLE_DECORATIONS, winTitle)
+}
+
+class SystemWindowAPI {
+    WinGetStyle(winTitle) => WinGetStyle(winTitle)
+    WinSetStyle(style, winTitle) => WinSetStyle(style, winTitle)
+    WinMove(x, y, w, h, winTitle) => WinMove(x, y, w, h, winTitle)
+    WinRestore(winTitle) => WinRestore(winTitle)
+    GetScreenWidth() => A_ScreenWidth
+    GetScreenHeight() => A_ScreenHeight
 }

--- a/ahk/test_WindowManager.ahk
+++ b/ahk/test_WindowManager.ahk
@@ -1,0 +1,94 @@
+#Requires AutoHotkey v2.0
+#Include A_ScriptDir "\..\Lib\v2\WindowManager.ahk"
+
+class MockWindowAPI {
+    __New() {
+        this.calls := []
+        this.mockStyle := 0xC00000 ; Has title
+        this.screenWidth := 1920
+        this.screenHeight := 1080
+    }
+
+    WinGetStyle(winTitle) {
+        this.calls.Push({method: "WinGetStyle", args: [winTitle]})
+        return this.mockStyle
+    }
+
+    WinSetStyle(style, winTitle) {
+        this.calls.Push({method: "WinSetStyle", args: [style, winTitle]})
+    }
+
+    WinMove(x, y, w, h, winTitle) {
+        this.calls.Push({method: "WinMove", args: [x, y, w, h, winTitle]})
+    }
+
+    WinRestore(winTitle) {
+        this.calls.Push({method: "WinRestore", args: [winTitle]})
+    }
+
+    GetScreenWidth() => this.screenWidth
+    GetScreenHeight() => this.screenHeight
+}
+
+TestToggleFakeFullscreen_MakeFullscreen() {
+    mockApi := MockWindowAPI()
+    mockApi.mockStyle := 0xC00000 ; Has title
+
+    ToggleFakeFullscreen("TestWindow", mockApi)
+
+    ; Verify calls
+    if (mockApi.calls.Length != 3) {
+        FileOpen("*", "w `n").Write("Fail: Expected 3 calls, got " mockApi.calls.Length "`n")
+        return false
+    }
+
+    if (mockApi.calls[1].method != "WinGetStyle") {
+        FileOpen("*", "w `n").Write("Fail: First call was not WinGetStyle`n")
+        return false
+    }
+
+    if (mockApi.calls[2].method != "WinSetStyle") {
+        FileOpen("*", "w `n").Write("Fail: Second call was not WinSetStyle`n")
+        return false
+    }
+
+    if (mockApi.calls[3].method != "WinMove") {
+        FileOpen("*", "w `n").Write("Fail: Third call was not WinMove`n")
+        return false
+    }
+
+    FileOpen("*", "w `n").Write("Pass: MakeFullscreen`n")
+    return true
+}
+
+TestToggleFakeFullscreen_RestoreWindow() {
+    mockApi := MockWindowAPI()
+    mockApi.mockStyle := 0 ; No title
+
+    ToggleFakeFullscreen("TestWindow", mockApi)
+
+    ; Verify calls
+    if (mockApi.calls.Length != 3) {
+        FileOpen("*", "w `n").Write("Fail: Expected 3 calls, got " mockApi.calls.Length "`n")
+        return false
+    }
+
+    if (mockApi.calls[2].method != "WinSetStyle") {
+        FileOpen("*", "w `n").Write("Fail: Second call was not WinSetStyle`n")
+        return false
+    }
+
+    if (mockApi.calls[3].method != "WinRestore") {
+        FileOpen("*", "w `n").Write("Fail: Third call was not WinRestore`n")
+        return false
+    }
+
+    FileOpen("*", "w `n").Write("Pass: RestoreWindow`n")
+    return true
+}
+
+TestToggleFakeFullscreen_MakeFullscreen()
+TestToggleFakeFullscreen_RestoreWindow()
+
+FileOpen("*", "w `n").Write("All tests complete.`n")
+ExitApp


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `ToggleFakeFullscreen` function in `Lib/v2/WindowManager.ahk` was untested because it relied on system-level window states and built-in AutoHotkey GUI functions, which are difficult to assert against and run locally without a Windows environment or spawning real windows.

📊 **Coverage:** What scenarios are now tested
- The code now includes a `SystemWindowAPI` class that wraps all stateful API calls (`WinGetStyle`, `WinSetStyle`, `WinMove`, `WinRestore`, and screen dimensions).
- `ToggleFakeFullscreen` has been refactored to accept this API wrapper as an injected dependency, allowing it to be easily mocked.
- Tests were added (`ahk/test_WindowManager.ahk`) using a `MockWindowAPI` that intercepts method calls and allows testing both the "Make Fullscreen" path (window currently has title decorations) and the "Restore Window" path (window is currently undecorated).
- Tests simulate exact bitwise states (0xC00000 vs 0) and verify that the expected operations are invoked in order.

✨ **Result:** The improvement in test coverage
The `ToggleFakeFullscreen` function's pure logic can now be robustly unit-tested purely via dependency injection. This makes the tests fast, fully deterministic, and completely immune to external desktop or UI state conditions.

---
*PR created automatically by Jules for task [1946412451043125752](https://jules.google.com/task/1946412451043125752) started by @Ven0m0*