### PR TITLE
🧹 Remove unused variable `ph` in Keys.ahk

### DIFF
--- a/ahk/Keys.ahk
+++ b/ahk/Keys.ahk
@@ -24,7 +24,6 @@ SetScrollLockState("AlwaysOff")
 mw := GetMonitorWidth()
 mh := GetMonitorHeight()
 pw := mw / 3
-ph := mh / 3
 lw := (2 * pw > 1024) ? 1024 : 2 * pw
 rw := mw - lw
 positions := Map()


### PR DESCRIPTION
🎯 **What:** Removed the unused `ph` variable assignment in `ahk/Keys.ahk`.
💡 **Why:** Reduces dead code, improving code maintainability.
✅ **Verification:** Visually inspected the code and tested via static search.
✨ **Result:** Cleaner code without changing functionality.

---
*PR created automatically by Jules for task [9509709409586516662](https://jules.google.com/task/9509709409586516662) started by @Ven0m0*