### PR TITLE
🧹 code health: remove unused sevenZEmuPrepperPath variable

### DIFF
--- a/Other/7zEmuPrepper/Final.ahk
+++ b/Other/7zEmuPrepper/Final.ahk
@@ -4,7 +4,6 @@
 ; 7zEmuPrepper command builder (for 7zEmuPrepper.ps1)
 ; Fields -> emits a ready-to-run PowerShell command. Includes a Copy button.
 
-sevenZEmuPrepperPath := ""
 sevenZipPath := ""
 emulatorPath := ""
 arguments := ""


### PR DESCRIPTION
🎯 What: Removed the unused `sevenZEmuPrepperPath` variable initialization from `Other/7zEmuPrepper/Final.ahk`.
💡 Why: This variable was completely unused in the script, reducing minor visual clutter and improving maintainability.
✅ Verification: Verified that only this specific unreferenced variable was removed, ensuring no `UnsetItemError` regressions are introduced for the other actively utilized script variables.
✨ Result: A slightly cleaner and more readable setup header for the 7zEmuPrepper AHK GUI.

---
*PR created automatically by Jules for task [7825629673263168611](https://jules.google.com/task/7825629673263168611) started by @Ven0m0*