### PR TITLE
🧹 Remove unused SelectFileOrDir overload

### DIFF
--- a/Other/7zEmuPrepper/Final.ahk
+++ b/Other/7zEmuPrepper/Final.ahk
@@ -46,15 +46,6 @@ gui.Add("Button", "x340 y430 w80 h23", "Exit").OnEvent("Click", (*) => ExitApp()
 gui.Show("w480 h470")
 return
 
-SelectFileOrDir(btn) {
-    global
-    text := btn.Text
-    if (text = "…") {
-        ; infer based on label order
-        idx := btn.Hwnd
-    }
-}
-
 ; Simplified per-control selection based on Y position
 SelectFileOrDir(btn, *) {
     y := btn.Pos.Y


### PR DESCRIPTION
🎯 **What:** 
Removed the obsolete, single-parameter `SelectFileOrDir(btn)` function from `Other/7zEmuPrepper/Final.ahk`.

💡 **Why:** 
The function `SelectFileOrDir(btn)` was fully superseded by a newer `SelectFileOrDir(btn, *)` overload later in the script that correctly handles parameter mismatches and correctly relies on `y` coordinate checking instead of global variable manipulation and partial hwnd indexing. Leaving the obsolete version in the script creates confusion and unnecessary code duplication.

✅ **Verification:** 
- Analysed the single usage of `SelectFileOrDir` in the script, which passes `(btn,*)` and effectively routes to the proper `SelectFileOrDir(btn, *)` function.
- Performed formatting checks ensuring DOS/CRLF (`unix2dos`) line endings and correct UTF-8 preservation natively.
- Validated with `git diff` that no other logic or behavior was modified.
- Simulated repository `SKILL.md` tests to rule out syntax breakages.

✨ **Result:** 
Cleaner, more maintainable code with dead code eliminated. The codebase is healthier without risking any behavior changes.

---
*PR created automatically by Jules for task [2542981698528075050](https://jules.google.com/task/2542981698528075050) started by @Ven0m0*