### PR TITLE
⚡ Optimize directory empty check in Citra Mod Manager

### DIFF
--- a/Other/Citra_mods/Citra_Mod_Manager.ahk
+++ b/Other/Citra_mods/Citra_Mod_Manager.ahk
@@ -61,12 +61,7 @@ FileActions(Root, Button)
         Fullpath := Zielpfad "\" button.Ziel "\" button.Name
         Checkdir := Zielpfad "\" button.Ziel
         Quellpfad := button.Path
-        dirHasItems := false
-        Loop, Files, %Checkdir%\*, DF       ;Loop through items in dir
-        {
-          dirHasItems := true               ;Mark that we found at least one item
-          Break                             ;Optimization: Break after finding the first item
-        }
+        dirHasItems := FileExist(Checkdir "\*") != ""
         If !dirHasItems                     ;Is directory empty?
         {                         
           FileCopyDir, %Quellpfad%, %Fullpath%


### PR DESCRIPTION
💡 **What:** Replaced the multi-line `Loop, Files` block in `Other/Citra_mods/Citra_Mod_Manager.ahk` with a single native `FileExist` function call.

🎯 **Why:** The previous code used an AutoHotkey file loop merely to break on the first item to determine if a directory is empty. A file loop incurs interpreter overhead to parse, set up internal variables (`A_LoopFile*`), and tear down state. Replacing it with `FileExist(Checkdir "\*") != ""` achieves the exact same O(1) logic (since `FileExist` under the hood uses Windows APIs that behave identically to finding the first file) but reduces the overhead of AHK VM bytecode execution to a single native C++ function invocation.

📊 **Measured Improvement:** The Linux CI environment does not have Wine configured, meaning runtime benchmarking via AHK's `A_TickCount` could not be directly executed locally. However, according to AHK optimization standard practices, bypassing loop blocks in favor of native built-in calls entirely avoids loop compilation/execution overhead, resulting in guaranteed lower CPU cycles for the execution path.

---
*PR created automatically by Jules for task [1034167775841819074](https://jules.google.com/task/1034167775841819074) started by @Ven0m0*