### PR TITLE
🧪 Refactor RequireAdmin tests for reliability

### DIFF
--- a/Lib/v2/AHK_Common.ahk
+++ b/Lib/v2/AHK_Common.ahk
@@ -7,7 +7,7 @@ InitUIA() {
     ; UIA is built-in in v2 (no-op, kept for compatibility)
 }
 
-RequireAdmin(mockIsAdmin := "", mockRun := "") {
+RequireAdmin(mockIsAdmin := "", mockRun := "", mockMsgBox := "", mockExitApp := "") {
     isAdmin := mockIsAdmin !== "" ? mockIsAdmin : A_IsAdmin
     if isAdmin
         return
@@ -16,10 +16,19 @@ RequireAdmin(mockIsAdmin := "", mockRun := "") {
             mockRun('*RunAs "' . A_ScriptFullPath . '"')
         else
             Run('*RunAs "' . A_ScriptFullPath . '"')
-        ExitApp()
+        if mockExitApp !== ""
+            mockExitApp()
+        else
+            ExitApp()
     } catch Error as err {
-        MsgBox("Failed to elevate: " . err.Message)
-        ExitApp()
+        if mockMsgBox !== ""
+            mockMsgBox("Failed to elevate: " . err.Message)
+        else
+            MsgBox("Failed to elevate: " . err.Message)
+        if mockExitApp !== ""
+            mockExitApp()
+        else
+            ExitApp()
     }
 }
 

--- a/Lib/v2/test_RequireAdmin.ahk
+++ b/Lib/v2/test_RequireAdmin.ahk
@@ -5,27 +5,32 @@ MockRun(target) {
     throw Error("Simulated elevation failure")
 }
 
-CloseMsgBox() {
-    if WinExist("ahk_class #32770") {
-        text := WinGetText("ahk_class #32770")
-        if InStr(text, "Failed to elevate: Simulated elevation failure") {
-            WinClose()
-            out := FileOpen("*", "w `n")
-            out.Write("Test Passed: Caught simulated elevation failure.`n")
-            out.Close()
-            ExitApp(0)
-        }
+global msgBoxText := ""
+
+MockMsgBox(text) {
+    global msgBoxText
+    msgBoxText := text
+}
+
+MockExitApp() {
+    global msgBoxText
+    out := FileOpen("*", "w `n")
+    if InStr(msgBoxText, "Failed to elevate: Simulated elevation failure") {
+        out.Write("Test Passed: Caught simulated elevation failure.`n")
+        out.Close()
+        ExitApp(0)
+    } else {
+        out.Write("Test Failed: Error MsgBox not encountered or incorrect text.`n")
+        out.Close()
+        ExitApp(1)
     }
 }
 
-; Set up a timer to catch and close the MsgBox asynchronously
-SetTimer(CloseMsgBox, 50)
-
 ; Trigger the error path
-RequireAdmin(false, MockRun)
+RequireAdmin(false, MockRun, MockMsgBox, MockExitApp)
 
 ; Fallback failure if the async process fails or the error is never triggered
 out := FileOpen("*", "w `n")
-out.Write("Test Failed: Error MsgBox not encountered or test timed out.`n")
+out.Write("Test Failed: Script did not exit through MockExitApp.`n")
 out.Close()
 ExitApp(1)

--- a/Other/Citra_mods/Citra_Mod_Manager.ahk
+++ b/Other/Citra_mods/Citra_Mod_Manager.ahk
@@ -42,8 +42,8 @@ loop, Files, % root "\*.*", D
 Gui, New, -MinimizeBox, Citra Mod Manager
 
 for each,button in Buttons                                                     ; Move through the Buttons object, one button at a time
-{                                                                              
-        Buttonhwnd := RegExReplace(button.Name, "[^A-Z0-9]")                   ; Sanitising the button name for use as a Hwnd 
+{
+        Buttonhwnd := RegExReplace(button.Name, "[^A-Z0-9]")                   ; Sanitising the button name for use as a Hwnd
         Gui Add, Button, % "+HWNDh" Buttonhwnd, % "Apply " button.Name " mod"  ; Adding the button to the GUI, with the Hwnd as an option
         ControlHandler := Func("FileActions").Bind(root, button)               ; Create Link from the button to the function we want
         GuiControl, +g, % h%Buttonhwnd%, % ControlHandler                      ; Update the button control to call the ControlHandler
@@ -68,7 +68,7 @@ FileActions(Root, Button)
           Break                             ;Optimization: Break after finding the first item
         }
         If !dirHasItems                     ;Is directory empty?
-        {                         
+        {
           FileCopyDir, %Quellpfad%, %Fullpath%
           MsgBox % "Copied " button.Name
         }

--- a/Other/Downloader/YT_Spotify_Downloader.ahk
+++ b/Other/Downloader/YT_Spotify_Downloader.ahk
@@ -8,7 +8,7 @@ Youtube := ""
 Spotify := ""
 
 Gui, Add, GroupBox, x22 y340 w430 h90 vMyGroupBox, Batch output
-Gui, Add, Edit, ReadOnly x32 y355 w410 h70 vOutput, 
+Gui, Add, Edit, ReadOnly x32 y355 w410 h70 vOutput,
 
 Gui, Add, GroupBox, x2 y19 w250 h30 , Youtube
 Gui, Add, Edit, x2 y34 w250 h20 vYoutube gYTDLP


### PR DESCRIPTION
🎯 **What:** The error catch path test in `test_RequireAdmin.ahk` relied on an asynchronous timer waiting for a physical `MsgBox` UI element, which is flaky and could halt execution.
📊 **Coverage:** Added mock dependency injection arguments (`mockMsgBox`, `mockExitApp`) to `RequireAdmin` in `Lib/v2/AHK_Common.ahk` to allow testing the elevation error path deterministically.
✨ **Result:** The `RequireAdmin` error handling test is now fully synchronous and headless, capturing logic errors instantly via mock objects without relying on window timeouts or manual GUI interaction.

---
*PR created automatically by Jules for task [11963092596810885988](https://jules.google.com/task/11963092596810885988) started by @Ven0m0*