### PR TITLE
🧪 Add tests for GetMonitorAtPos in WindowManager

### DIFF
--- a/Lib/v2/WindowManager.ahk
+++ b/Lib/v2/WindowManager.ahk
@@ -46,10 +46,13 @@ WaitForProcess(processName, timeout := 30) {
     return ProcessWait(processName, timeout) != 0
 }
 
-GetMonitorAtPos(x, y) {
-    count := MonitorGetCount()
+GetMonitorAtPos(x, y, api := "") {
+    if !api
+        api := SystemWindowAPI()
+
+    count := api.MonitorGetCount()
     Loop count {
-        MonitorGet(A_Index, &l, &t, &r, &b)
+        api.MonitorGet(A_Index, &l, &t, &r, &b)
         if (l <= x && x <= r && t <= y && y <= b)
             return A_Index
     }
@@ -96,4 +99,6 @@ class SystemWindowAPI {
     WinRestore(winTitle) => WinRestore(winTitle)
     GetScreenWidth() => A_ScreenWidth
     GetScreenHeight() => A_ScreenHeight
+    MonitorGetCount() => MonitorGetCount()
+    MonitorGet(N, &Left, &Top, &Right, &Bottom) => MonitorGet(N, &Left, &Top, &Right, &Bottom)
 }

--- a/ahk/test_WindowManager.ahk
+++ b/ahk/test_WindowManager.ahk
@@ -7,6 +7,7 @@ class MockWindowAPI {
         this.mockStyle := 0xC00000 ; Has title
         this.screenWidth := 1920
         this.screenHeight := 1080
+        this.monitors := []
     }
 
     WinGetStyle(winTitle) {
@@ -28,6 +29,21 @@ class MockWindowAPI {
 
     GetScreenWidth() => this.screenWidth
     GetScreenHeight() => this.screenHeight
+
+    MonitorGetCount() {
+        this.calls.Push({method: "MonitorGetCount", args: []})
+        return this.monitors.Length
+    }
+
+    MonitorGet(N, &Left, &Top, &Right, &Bottom) {
+        this.calls.Push({method: "MonitorGet", args: [N]})
+        if (N > 0 && N <= this.monitors.Length) {
+            Left := this.monitors[N].l
+            Top := this.monitors[N].t
+            Right := this.monitors[N].r
+            Bottom := this.monitors[N].b
+        }
+    }
 }
 
 TestToggleFakeFullscreen_MakeFullscreen() {
@@ -87,8 +103,58 @@ TestToggleFakeFullscreen_RestoreWindow() {
     return true
 }
 
+TestGetMonitorAtPos_InsideMonitor() {
+    mockApi := MockWindowAPI()
+    mockApi.monitors := [
+        {l: 0, t: 0, r: 1920, b: 1080}
+    ]
+
+    res := GetMonitorAtPos(500, 500, mockApi)
+    if (res != 1) {
+        FileOpen("*", "w `n").Write("Fail: Expected 1, got " res "`n")
+        return false
+    }
+    FileOpen("*", "w `n").Write("Pass: GetMonitorAtPos_InsideMonitor`n")
+    return true
+}
+
+TestGetMonitorAtPos_OutsideMonitors() {
+    mockApi := MockWindowAPI()
+    mockApi.monitors := [
+        {l: 0, t: 0, r: 1920, b: 1080}
+    ]
+
+    res := GetMonitorAtPos(-100, 500, mockApi)
+    if (res != -1) {
+        FileOpen("*", "w `n").Write("Fail: Expected -1, got " res "`n")
+        return false
+    }
+    FileOpen("*", "w `n").Write("Pass: GetMonitorAtPos_OutsideMonitors`n")
+    return true
+}
+
+TestGetMonitorAtPos_MultipleMonitors() {
+    mockApi := MockWindowAPI()
+    mockApi.monitors := [
+        {l: 0, t: 0, r: 1920, b: 1080},
+        {l: -1920, t: 0, r: 0, b: 1080}
+    ]
+
+    res := GetMonitorAtPos(-500, 500, mockApi)
+    if (res != 2) {
+        FileOpen("*", "w `n").Write("Fail: Expected 2, got " res "`n")
+        return false
+    }
+    FileOpen("*", "w `n").Write("Pass: GetMonitorAtPos_MultipleMonitors`n")
+    return true
+}
+
 TestToggleFakeFullscreen_MakeFullscreen()
 TestToggleFakeFullscreen_RestoreWindow()
+
+TestGetMonitorAtPos_InsideMonitor()
+TestGetMonitorAtPos_OutsideMonitors()
+TestGetMonitorAtPos_MultipleMonitors()
 
 FileOpen("*", "w `n").Write("All tests complete.`n")
 ExitApp


### PR DESCRIPTION
🎯 **What:** The testing gap addressed. Added tests for GetMonitorAtPos by refactoring it to accept an optional 'api' parameter to inject mock system APIs (MonitorGetCount, MonitorGet) for boundary logic testing.
📊 **Coverage:** What scenarios are now tested. Added TestGetMonitorAtPos_InsideMonitor, TestGetMonitorAtPos_OutsideMonitors, and TestGetMonitorAtPos_MultipleMonitors inside test_WindowManager.ahk.
✨ **Result:** The improvement in test coverage. Reliable validation of multi-monitor boundary overlap checks without manual visual inspection.

---
*PR created automatically by Jules for task [13991597786380503469](https://jules.google.com/task/13991597786380503469) started by @Ven0m0*