### PR TITLE
🧪 Add tests for SetKey edge cases and fix regex bug

### DIFF
--- a/Other/Citra_per_game_config/v2/CitraConfigHelpers.ahk
+++ b/Other/Citra_per_game_config/v2/CitraConfigHelpers.ahk
@@ -38,7 +38,7 @@ RegExEscape(str) {
 SetKey(content, key, value) {
     pat := "m)^(" . RegExEscape(key) . ")\s*=.*$"
     if RegExMatch(content, pat)
-        return RegExReplace(content, pat, "$1=" value, , 1)
+        return RegExReplace(content, pat, "$1=" StrReplace(value, "$", "$$"), , 1)
     else
         return content "`n" key "=" value
 }

--- a/Other/Citra_per_game_config/v2/CitraConfigHelpers_Test.ahk
+++ b/Other/Citra_per_game_config/v2/CitraConfigHelpers_Test.ahk
@@ -73,6 +73,22 @@ TestSetKey() {
     content2 := "path\to\file=exists`n"
     result := SetKey(content2, "path\to\file", "updated")
     AssertEqual(InStr(result, "path\to\file=updated") > 0, true, "SetKey updates key with backslashes")
+
+    ; Test 6: Empty value
+    result := SetKey(content, "key1", "")
+    AssertEqual(InStr(result, "key1=") > 0 && InStr(result, "key1=value1") == 0, true, "SetKey handles empty value")
+
+    ; Test 7: Value with literal $ sign
+    result := SetKey(content, "key1", "val$ue")
+    AssertEqual(InStr(result, "key1=val$ue") > 0, true, "SetKey handles value with literal $ sign")
+
+    ; Test 8: Value with literal $1
+    result := SetKey(content, "key2", "val$1ue")
+    AssertEqual(InStr(result, "key2=val$1ue") > 0, true, "SetKey handles value with literal $1")
+
+    ; Test 9: Add new key with $ sign
+    result := SetKey(content, "key4", "new$val")
+    AssertEqual(InStr(result, "key4=new$val") > 0, true, "SetKey adds new key with $ sign")
 }
 
 TestReplaceInFile() {


### PR DESCRIPTION
🎯 **What:** `SetKey` was missing tests for various edge cases. Specifically, values containing literal `$` signs would be evaluated as regex backreferences, corrupting configs.
📊 **Coverage:** Added tests for handling empty values, literal `$` signs, literal `$1`, and appending new keys containing `$`.
✨ **Result:** Discovered and patched a bug using `StrReplace(value, "$", "$$")` before `RegExReplace` evaluates it. Test coverage increased and reliability is improved.

---
*PR created automatically by Jules for task [17628847229633971450](https://jules.google.com/task/17628847229633971450) started by @Ven0m0*