### PR TITLE
⚡ Optimize string concatenation and logic in Citra 3DS Manager

### DIFF
--- a/Other/Citra_mods/Citra_3DS_Manager.ahk
+++ b/Other/Citra_mods/Citra_3DS_Manager.ahk
@@ -62,23 +62,32 @@ UpdateConfig(content, updates){
   VarSetCapacity(newContent, (StrLen(content) + updates.Count() * 100 + 1) * (A_IsUnicode ? 2 : 1))
   newContent := ""
 
+  remCount := remaining.Count()
+
   Loop, Parse, content, `n, `r
   {
     line := A_LoopField
-    pos := InStr(line, "=")
-    if (pos > 1){
-      keyCandidate := RTrim(SubStr(line, 1, pos-1))
-      if (remaining.HasKey(keyCandidate)){
-        val := remaining[keyCandidate]
-        line := keyCandidate "=" val
-        remaining.Delete(keyCandidate)
+    if (remCount > 0) {
+      pos := InStr(line, "=")
+      if (pos > 1){
+        keyCandidate := RTrim(SubStr(line, 1, pos-1))
+        if (remaining.HasKey(keyCandidate)){
+          val := remaining[keyCandidate]
+          line := keyCandidate "=" val
+          remaining.Delete(keyCandidate)
+          remCount--
+        }
       }
     }
-    newContent .= line "`n"
+    newContent .= line
+    newContent .= "`n"
   }
 
   for k, v in remaining {
-     newContent .= k "=" v "`n"
+     newContent .= k
+     newContent .= "="
+     newContent .= v
+     newContent .= "`n"
   }
 
   return SubStr(newContent, 1, -1)


### PR DESCRIPTION
💡 **What:**
- Introduced a `remCount` early-exit guard to skip dictionary lookups (`InStr`, `HasKey`) when all configuration updates are satisfied.
- Replaced multi-part chained string concatenation (`var .= a b c`) with single-part consecutive assignments (`var .= a`, `var .= b`).

🎯 **Why:**
- While the script already correctly utilized `VarSetCapacity` prior to the loop to allocate memory, it was using chained `.=` within the parsing loop, which inherently causes AutoHotkey v1 to allocate tiny temporary strings prior to the main append operation.
- The original logic forced an `InStr` and `HasKey` lookup for every single line of the configuration file, even if all modifications had already been applied near the top of the file.

📊 **Measured Improvement:**
*Note:* As this system operates in a headless Linux environment, direct benchmark execution against the native AHK v1 interpreter was not feasible. However, theoretical runtime complexity checks map directly to established AHK v1 optimization best practices.
- Lookup logic transitions from O(N) to O(K) where N is file lines and K is the subset of lines until all updates are satisfied. This yields faster processing, especially for larger config files with updates concentrated near the start.
- Single-part string assignment explicitly bypasses the well-documented v1 temporary variable intermediate allocations, reducing memory churn.

---
*PR created automatically by Jules for task [12318181205727613221](https://jules.google.com/task/12318181205727613221) started by @Ven0m0*