### PR TITLE
🧪 [Testing] Add timeout error path test for WaitForWindow

### DIFF
--- a/Lib/v2/WindowManager.ahk
+++ b/Lib/v2/WindowManager.ahk
@@ -33,13 +33,11 @@ MakeFullscreen(winTitle) {
     MaximizeWindow(winTitle)
 }
 
-WaitForWindow(winTitle, timeout := 30) {
-    try {
-        WinWait(winTitle, , timeout)
-        return true
-    } catch TimeoutError {
-        return false
-    }
+WaitForWindow(winTitle, timeout := 30, api := "") {
+    if !api
+        api := SystemWindowAPI()
+
+    return api.WinWait(winTitle, , timeout) != 0
 }
 
 WaitForProcess(processName, timeout := 30) {
@@ -93,6 +91,7 @@ RestoreWindowBorders(winTitle) {
 }
 
 class SystemWindowAPI {
+    WinWait(winTitle, winText?, timeout?) => WinWait(winTitle, winText?, timeout?)
     WinGetStyle(winTitle) => WinGetStyle(winTitle)
     WinSetStyle(style, winTitle) => WinSetStyle(style, winTitle)
     WinMove(x, y, w, h, winTitle) => WinMove(x, y, w, h, winTitle)

--- a/ahk/test_WindowManager.ahk
+++ b/ahk/test_WindowManager.ahk
@@ -10,6 +10,11 @@ class MockWindowAPI {
         this.monitors := []
     }
 
+    WinWait(winTitle, winText:="", timeout:="") {
+        this.calls.Push({method: "WinWait", args: [winTitle, winText, timeout]})
+        return 0 ; Simulate timeout
+    }
+
     WinGetStyle(winTitle) {
         this.calls.Push({method: "WinGetStyle", args: [winTitle]})
         return this.mockStyle
@@ -149,12 +154,50 @@ TestGetMonitorAtPos_MultipleMonitors() {
     return true
 }
 
+
+TestWaitForWindow_Timeout() {
+    mockApi := MockWindowAPI()
+
+    res := WaitForWindow("FakeWindow", 0.1, mockApi)
+
+    ; Verify result
+    if (res != false) {
+        FileOpen("*", "w `n").Write("Fail: Expected false, got " res "`n")
+        return false
+    }
+
+    ; Verify calls
+    if (mockApi.calls.Length != 1) {
+        FileOpen("*", "w `n").Write("Fail: Expected 1 call, got " mockApi.calls.Length "`n")
+        return false
+    }
+
+    if (mockApi.calls[1].method != "WinWait") {
+        FileOpen("*", "w `n").Write("Fail: First call was not WinWait`n")
+        return false
+    }
+
+    if (mockApi.calls[1].args[1] != "FakeWindow") {
+        FileOpen("*", "w `n").Write("Fail: Expected winTitle 'FakeWindow', got '" mockApi.calls[1].args[1] "'`n")
+        return false
+    }
+
+    if (mockApi.calls[1].args[3] != 0.1) {
+        FileOpen("*", "w `n").Write("Fail: Expected timeout 0.1, got '" mockApi.calls[1].args[3] "'`n")
+        return false
+    }
+
+    FileOpen("*", "w `n").Write("Pass: WaitForWindow_Timeout`n")
+    return true
+}
+
 TestToggleFakeFullscreen_MakeFullscreen()
 TestToggleFakeFullscreen_RestoreWindow()
 
 TestGetMonitorAtPos_InsideMonitor()
 TestGetMonitorAtPos_OutsideMonitors()
 TestGetMonitorAtPos_MultipleMonitors()
+TestWaitForWindow_Timeout()
 
 FileOpen("*", "w `n").Write("All tests complete.`n")
 ExitApp


### PR DESCRIPTION
🎯 **What:** 
- The `WaitForWindow` function in `Lib/v2/WindowManager.ahk` was improperly catching `TimeoutError`, which `WinWait` in AutoHotkey v2 no longer throws (it returns 0 instead on timeout).
- Refactored `WaitForWindow` to support Dependency Injection for its API calls.
- Fixed the timeout return value check.
- Added a dedicated test for the timeout scenario in `ahk/test_WindowManager.ahk`.

📊 **Coverage:**
- Now tests the exact scenario where the window never appears and a timeout occurs.
- Evaluates correct execution arguments and validates that `WaitForWindow` propagates the `false` return state.

✨ **Result:**
- Improved overall code coverage.
- Fixed an underlying logical bug inside the error-handling path itself.

---
*PR created automatically by Jules for task [1221782000402455162](https://jules.google.com/task/1221782000402455162) started by @Ven0m0*