### PR TITLE
Pre-cache MCP server packages and Playwright browser for Copilot

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -34,9 +34,11 @@ jobs:
         run: |
           set -euxo pipefail
           # The agent launches these servers via `npx -y <pkg>@latest`. Installing
-          # them globally warms the npm cache so they resolve quickly/offline once
-          # the runtime firewall is in place. Keep this list in sync with the
-          # `type: "local"` servers in the repo's Copilot MCP configuration.
+          # them globally warms the npm cache so they resolve quickly once the
+          # runtime firewall is in place. Keep this list in sync with the
+          # `type: "local"` MCP servers configured for the coding agent under
+          # repo Settings -> Copilot -> coding agent (configured there, not in a
+          # file in this repo).
           npm install -g \
             @playwright/mcp@latest \
             fast-filesystem-mcp@latest \

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,10 @@ permissions:
   contents: read
 
 jobs:
+  # NOTE: The job MUST stay named `copilot-setup-steps` or the Copilot coding
+  # agent will not pick it up. These steps run BEFORE the agent's firewall is
+  # enabled, so anything the agent's MCP servers need at runtime should be
+  # downloaded/cached here.
   copilot-setup-steps:
     runs-on: ubuntu-latest
     steps:
@@ -21,6 +25,31 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+
+      - name: Pre-install local (stdio) MCP server packages
+        shell: bash
+        env:
+          NPM_CONFIG_FUND: "false"
+          NPM_CONFIG_AUDIT: "false"
+        run: |
+          set -euxo pipefail
+          # The agent launches these servers via `npx -y <pkg>@latest`. Installing
+          # them globally warms the npm cache so they resolve quickly/offline once
+          # the runtime firewall is in place. Keep this list in sync with the
+          # `type: "local"` servers in the repo's Copilot MCP configuration.
+          npm install -g \
+            @playwright/mcp@latest \
+            fast-filesystem-mcp@latest \
+            octocode-mcp@latest \
+            yggdrasil-mcp@latest
+
+      - name: Install Playwright browser (Chromium)
+        shell: bash
+        run: |
+          set -euxo pipefail
+          # The playwright MCP server needs a browser binary present. Fetch
+          # Chromium and its OS dependencies before the firewall blocks downloads.
+          npx --yes playwright install --with-deps chromium
 
       - name: Note Windows validation workflows
         shell: bash


### PR DESCRIPTION
## Summary

Extends the `copilot-setup-steps` workflow to pre-install and cache MCP (Model Context Protocol) server packages and Playwright browser binaries before the Copilot agent's runtime firewall is enabled. This ensures the agent can launch its local stdio MCP servers and use Playwright without network access once the firewall is active.

## Key Changes

- **Added clarifying comment** on the `copilot-setup-steps` job explaining its role in the agent setup pipeline and the requirement to maintain the job name for agent discovery.

- **Pre-install local MCP server packages** via `npm install -g`:
  - `@playwright/mcp@latest`
  - `fast-filesystem-mcp@latest`
  - `octocode-mcp@latest`
  - `yggdrasil-mcp@latest`
  - Disables npm fund and audit output to reduce noise
  - Includes inline comment noting these must stay in sync with the repo's Copilot MCP configuration

- **Pre-install Playwright browser (Chromium)**:
  - Runs `npx --yes playwright install --with-deps chromium` to fetch the browser binary and OS dependencies
  - Ensures Playwright MCP server has required browser binaries available before firewall activation

## Implementation Details

Both new steps run before the agent's firewall is enabled, warming the npm cache and pre-staging runtime dependencies so the agent can operate offline once network restrictions are in place. The steps include inline documentation to clarify their purpose and maintenance requirements.

https://claude.ai/code/session_01AfnF51garpZ7ajmV6M7ZMF